### PR TITLE
Introduce deposit and withdraw functions, rename cashier contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ also keeps records for developer wallet, fees, and `CMAccount` implementation
 address. Accounts can only be upgraded to this implementation address that the
 manager holds.
 
-### MessengerCashier.sol
+### ChequeManager.sol
 
-The `MessengerCashier` contract handles the processing of cheques. It verifies the
+The `ChequeManager` contract handles the processing of cheques. It verifies the
 signatures, checks the validity of the cheques, and transfers the funds between
 accounts. It also calculates the developer fee and transfers it to the developer's
 wallet.

--- a/contracts/account/ChequeManager.sol
+++ b/contracts/account/ChequeManager.sol
@@ -9,13 +9,13 @@ import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 
 /**
- * @dev MessengerCashier manages, verifies, and cashes in messenger cheques.
+ * @dev ChequeManager manages, verifies, and cashes in messenger cheques.
  *
  * EIP712 Domain name & version:
  *   DOMAIN_NAME = "CaminoMessenger"
  *   DOMAIN_VERSION= "1"
  */
-abstract contract MessengerCashier is Initializable {
+abstract contract ChequeManager is Initializable {
     using ECDSA for bytes32;
     using Address for address payable;
 
@@ -136,7 +136,7 @@ abstract contract MessengerCashier is Initializable {
      *   uint256 chainid;
      * }
      */
-    function __MessengerCashier_init() internal onlyInitializing {
+    function __ChequeManager_init() internal onlyInitializing {
         DOMAIN_SEPARATOR = keccak256(
             abi.encode(DOMAIN_TYPEHASH, keccak256("CaminoMessenger"), keccak256("1"), block.chainid)
         );
@@ -263,6 +263,8 @@ abstract contract MessengerCashier is Initializable {
      * @dev Sets `CashIn(uint256 lastCounter, uint256 lastAmount)` for given `fromBot`, `toBot` pair.
      */
     function setLastCashIn(address fromBot, address toBot, uint256 counter, uint256 amount) internal {
+        payable(address(this)).sendValue(amount);
+
         lastCashIns[fromBot][toBot] = LastCashIn(counter, amount);
     }
 

--- a/contracts/factory/CMAccountManager.sol
+++ b/contracts/factory/CMAccountManager.sol
@@ -16,7 +16,13 @@ import "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol
 
 // ABI of the CMAccount implementation contract
 interface ICMAccount {
-    function initialize(address manager, address owner, address pauser, address upgrader) external;
+    function initialize(
+        address manager,
+        address owner,
+        address pauser,
+        address upgrader,
+        bool anyOneCanDeposit
+    ) external;
 }
 
 /// @custom:security-contact https://r.xyz/program/camino-network
@@ -174,12 +180,18 @@ contract CMAccountManager is
     function createCMAccount(
         address initialOwner,
         address pauser,
-        address upgrader
+        address upgrader,
+        bool anyOneCanDeposit
     ) external nonReentrant whenNotPaused returns (address) {
-        return _createCMAccount(initialOwner, pauser, upgrader);
+        return _createCMAccount(initialOwner, pauser, upgrader, anyOneCanDeposit);
     }
 
-    function _createCMAccount(address initialOwner, address pauser, address upgrader) private returns (address) {
+    function _createCMAccount(
+        address initialOwner,
+        address pauser,
+        address upgrader,
+        bool anyOneCanDeposit
+    ) private returns (address) {
         // Checks
         address latestAccountImplementation = _latestAccountImplementation;
         if (latestAccountImplementation.code.length == 0) {
@@ -197,7 +209,7 @@ contract CMAccountManager is
         cmAccounts[address(cmAccountProxy)] = true;
 
         // Initialize the CMAccount
-        ICMAccount(address(cmAccountProxy)).initialize(address(this), initialOwner, pauser, upgrader);
+        ICMAccount(address(cmAccountProxy)).initialize(address(this), initialOwner, pauser, upgrader, anyOneCanDeposit);
 
         return address(cmAccountProxy);
     }

--- a/test/CMAccountManager.js
+++ b/test/CMAccountManager.js
@@ -4,7 +4,8 @@ const { expect } = require("chai");
 const { ethers, upgrades } = require("hardhat");
 
 // @dev TODO: Extend and tidy up tests
-// @dev TODO: Add MessengerCashier tests
+// @dev TODO: Add ChequeManager tests
+// @dev TODO: Use fixtures for CM account creations in various tests
 
 describe("CMAccountManager", function () {
     async function deployCMAccountManagerFixture() {
@@ -86,12 +87,24 @@ describe("CMAccountManager", function () {
             const { cmAccountManager, cmAccount, initialOwner, pauser, upgrader, otherAccount } =
                 await loadFixture(deployCMAccountManagerFixture);
 
+            const anyOneCanDeposit = true;
+
             await expect(
-                await cmAccountManager.createCMAccount(initialOwner.address, pauser.address, upgrader.address),
+                await cmAccountManager.createCMAccount(
+                    initialOwner.address,
+                    pauser.address,
+                    upgrader.address,
+                    anyOneCanDeposit,
+                ),
             ).to.emit(cmAccountManager, "CMAccountCreated");
 
             // Create CMAccount
-            const tx = await cmAccountManager.createCMAccount(initialOwner.address, pauser.address, upgrader.address);
+            const tx = await cmAccountManager.createCMAccount(
+                initialOwner.address,
+                pauser.address,
+                upgrader.address,
+                anyOneCanDeposit,
+            );
             const receipt = await tx.wait();
 
             // Decode the event log
@@ -100,6 +113,7 @@ describe("CMAccountManager", function () {
                     return cmAccountManager.interface.parseLog(log).name === "CMAccountCreated";
                 } catch (e) {
                     return false;
+                    const anyOneCanDeposit = true;
                 }
             });
 
@@ -115,8 +129,15 @@ describe("CMAccountManager", function () {
         it("should revert if the owner address is invalid", async function () {
             const { cmAccountManager, cmAccount, pauser, upgrader } = await loadFixture(deployCMAccountManagerFixture);
 
+            const anyOneCanDeposit = true;
+
             await expect(
-                cmAccountManager.createCMAccount(ethers.ZeroAddress, pauser.address, upgrader.address),
+                cmAccountManager.createCMAccount(
+                    ethers.ZeroAddress,
+                    pauser.address,
+                    upgrader.address,
+                    anyOneCanDeposit,
+                ),
             ).to.be.revertedWithCustomError(cmAccountManager, "CMAccountInvalidOwner");
         });
     });
@@ -145,11 +166,18 @@ describe("CMAccountManager", function () {
             await cmAccountManager.connect(pauser).pause();
             expect(await cmAccountManager.paused()).to.be.true;
 
+            const anyOneCanDeposit = true;
+
             // Try to create CMAccount
             await expect(
                 cmAccountManager
                     .connect(pauser)
-                    .createCMAccount(otherAccount.address, otherAccount.address, otherAccount.address),
+                    .createCMAccount(
+                        otherAccount.address,
+                        otherAccount.address,
+                        otherAccount.address,
+                        anyOneCanDeposit,
+                    ),
             ).to.be.revertedWithCustomError(cmAccountManager, "EnforcedPause");
         });
     });
@@ -162,8 +190,15 @@ describe("CMAccountManager", function () {
             // Get old implementation address from the factory
             const oldImplementation = await cmAccountManager.getAccountImplementation();
 
+            const anyOneCanDeposit = true;
+
             // Create CMAccount with old implementation
-            const tx = await cmAccountManager.createCMAccount(initialOwner.address, pauser.address, upgrader.address);
+            const tx = await cmAccountManager.createCMAccount(
+                initialOwner.address,
+                pauser.address,
+                upgrader.address,
+                anyOneCanDeposit,
+            );
             const receipt = await tx.wait();
 
             // Decode the event log
@@ -207,8 +242,15 @@ describe("CMAccountManager", function () {
             const { cmAccountManager, cmAccount, initialOwner, pauser, upgrader, otherAccount } =
                 await loadFixture(deployCMAccountManagerFixture);
 
+            const anyOneCanDeposit = true;
+
             // Create CMAccount
-            const tx = await cmAccountManager.createCMAccount(initialOwner.address, pauser.address, upgrader.address);
+            const tx = await cmAccountManager.createCMAccount(
+                initialOwner.address,
+                pauser.address,
+                upgrader.address,
+                anyOneCanDeposit,
+            );
             const receipt = await tx.wait();
 
             // Decode the event log
@@ -248,8 +290,15 @@ describe("CMAccountManager", function () {
             const { cmAccountManager, cmAccount, initialOwner, pauser, upgrader } =
                 await loadFixture(deployCMAccountManagerFixture);
 
+            const anyOneCanDeposit = true;
+
             // Create CMAccount
-            const tx = await cmAccountManager.createCMAccount(initialOwner.address, pauser.address, upgrader.address);
+            const tx = await cmAccountManager.createCMAccount(
+                initialOwner.address,
+                pauser.address,
+                upgrader.address,
+                anyOneCanDeposit,
+            );
             const receipt = await tx.wait();
 
             // Decode the event log


### PR DESCRIPTION
This PR:
- Adds `deposit` and `withdraw` functions to `CMAccount`.
- Deposits are restricted to only `DEPOSITER_ROLE` if the `anyOneCanDeposit` variable is false, else any one can use the deposit function to deposit.
- Better name for cheques contract: `MessengerCashier` --> `ChequeManager`.

Note: Project is work in progress. Creating PRs just to record changes. I will merge the PR immediately. 