### PR TITLE
Cheques "to" field can only be another CM Account

### DIFF
--- a/contracts/account/CMAccount.sol
+++ b/contracts/account/CMAccount.sol
@@ -22,6 +22,8 @@ interface ICMAccountManager {
     function getDeveloperFeeBp() external view returns (uint256);
 
     function getDeveloperWallet() external view returns (address);
+
+    function isCMAccount(address account) external view returns (bool);
 }
 
 /**
@@ -162,6 +164,13 @@ contract CMAccount is Initializable, PausableUpgradeable, AccessControlUpgradeab
      */
     function isBotAllowed(address bot) public view override returns (bool) {
         return hasRole(CHEQUE_OPERATOR_ROLE, bot);
+    }
+
+    /**
+     * @dev Return true if address is a registered CMAccount on the CMAccountManager
+     */
+    function isCMAccount(address account) internal view override returns (bool) {
+        return ICMAccountManager(_manager).isCMAccount(account);
     }
 
     /**

--- a/test/CMAccount.test.js
+++ b/test/CMAccount.test.js
@@ -40,7 +40,7 @@ describe("CMAccount", function () {
                 .withArgs(oldImplementationAddress, newImplementationAddress);
         });
 
-        it("should revert to upgrade if implementation address does not match", async function () {
+        it("should revert upgrade if implementation address does not match", async function () {
             const { cmAccountManager, cmAccount } = await loadFixture(deployAndConfigureAllFixture);
 
             // Old implementation
@@ -60,7 +60,7 @@ describe("CMAccount", function () {
                 .withArgs(oldImplementationAddress, newImplementationAddress);
         });
 
-        it("should revert to upgrade to an invalid implementation", async function () {
+        it("should revert upgrade if address is not uups upgradeable", async function () {
             const { cmAccountManager, cmAccount } = await loadFixture(deployAndConfigureAllFixture);
 
             // Old implementation
@@ -82,7 +82,7 @@ describe("CMAccount", function () {
                 .withArgs(newImplementationAddress);
         });
 
-        it("should revert to upgrade to an implementation address is the same", async function () {
+        it("should revert upgrade if address is same with the current one", async function () {
             const { cmAccountManager, cmAccount } = await loadFixture(deployAndConfigureAllFixture);
 
             // Old implementation
@@ -94,6 +94,7 @@ describe("CMAccount", function () {
                 .withArgs(oldImplementationAddress, oldImplementationAddress);
         });
     });
+
     describe("Registering Bots", function () {
         it("should register bots correctly", async function () {
             const { cmAccountManager, cmAccount } = await loadFixture(deployAndConfigureAllFixture);
@@ -109,6 +110,7 @@ describe("CMAccount", function () {
             await expect(await cmAccount.isBotAllowed(botAddr)).to.be.true;
         });
     });
+
     describe("Deposit", function () {
         it("should allow anyone to send funds", async function () {
             const { cmAccountManager, cmAccount } = await loadFixture(deployAndConfigureAllFixture);

--- a/test/CMAccountManager.test.js
+++ b/test/CMAccountManager.test.js
@@ -102,6 +102,7 @@ describe("CMAccountManager", function () {
             await expect(await cmAccountManager.getDeveloperFeeBp()).to.be.equal(newFeeBp);
         });
     });
+
     describe("Upgrades", function () {
         it("should upgrade correctly", async function () {
             // Set up signers
@@ -129,6 +130,7 @@ describe("CMAccountManager", function () {
             );
         });
     });
+
     describe("CMAccount Implementation", function () {
         it("should set CMAccount implementation correctly", async function () {
             // Set up signers
@@ -185,6 +187,7 @@ describe("CMAccountManager", function () {
             ).to.be.revertedWithCustomError(cmAccountManager, "AccessControlUnauthorizedAccount");
         });
     });
+
     describe("Pausable", function () {
         it("should pause and unpause the contract", async function () {
             // Set up signers
@@ -211,6 +214,7 @@ describe("CMAccountManager", function () {
             );
         });
     });
+
     describe("CMAccount", function () {
         it("should create CMAccount correctly", async function () {
             // Set up signers

--- a/test/ChequeManager.test.js
+++ b/test/ChequeManager.test.js
@@ -1,6 +1,3 @@
-/**
- * @dev Cheques
- */
 const { loadFixture } = require("@nomicfoundation/hardhat-toolbox/network-helpers");
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
@@ -42,6 +39,7 @@ describe("ChequeManager", function () {
             const cmAccountMessengerChequeTypeHash = await cmAccount.MESSENGER_CHEQUE_TYPEHASH();
             expect(cmAccountMessengerChequeTypeHash).to.be.equal(calculatedMessengerChequeTypeHash);
         });
+
         it("Should return the correct DOMAIN_TYPEHASH", async function () {
             const { cmAccount } = await loadFixture(deployCMAccountWithDepositFixture);
 
@@ -50,7 +48,7 @@ describe("ChequeManager", function () {
             const cmAccountDomainTypeHash = await cmAccount.DOMAIN_TYPEHASH();
             expect(cmAccountDomainTypeHash).to.be.equal(calculatedDomainTypeHash);
         });
-        //it("Should initialize the DOMAIN_SEPARATOR correctly", async function () {});
+
         it("Should initialize the DOMAIN_SEPARATOR correctly", async function () {
             const { cmAccount } = await loadFixture(deployCMAccountWithDepositFixture);
 
@@ -60,6 +58,7 @@ describe("ChequeManager", function () {
             const cmAccountDomainSeparator = await cmAccount.DOMAIN_SEPARATOR();
             expect(cmAccountDomainSeparator).to.be.equal(calculatedDomainSeparator);
         });
+
         it("Should hash the messenger cheque correctly", async function () {
             const { cmAccount } = await loadFixture(deployCMAccountWithDepositFixture);
             const cheque = {
@@ -78,10 +77,6 @@ describe("ChequeManager", function () {
             expect(hashFromContract).to.be.equal(calculatedHash);
         });
 
-        /**
-         * Test hashing TypedData
-         * @dev
-         */
         it("Should hash TypedData correctly", async function () {
             // Set up signers and contract instance
             const { cmAccount } = await loadFixture(deployCMAccountWithDepositFixture);
@@ -109,101 +104,37 @@ describe("ChequeManager", function () {
             // Assert that the calculated typedDataHash is equal to the typedDataHash from contract
             expect(typedDataHashFromContract).to.be.equal(calculatedTypedDataHash);
         });
+    });
 
-        it("REMOVE Should hash MessengerCheque correctly", async function () {
-            // Set up signers
-            await setupSigners();
+    describe("Cheque Operations", function () {
+        it("Should verify a cheque with a valid signature", async function () {
+            const { cmAccount, cmAccountManager } = await loadFixture(deployCMAccountWithDepositFixture);
 
-            const { cmAccount } = await loadFixture(deployCMAccountWithDepositFixture);
-            const cheque = {
-                fromCMAccount: await cmAccount.getAddress(),
-                toCMAccount: signers.otherAccount1.address,
-                toBot: signers.otherAccount2.address,
-                counter: 1,
-                amount: ethers.parseEther("1"),
-                timestamp: 1721777321,
-            };
-            const hash = await cmAccount.hashMessengerCheque(cheque);
-            // console.log("Cheque Hash From Contract:", hash);
-            expect(hash).to.not.be.reverted;
-
-            const typedDataFromContract = await cmAccount.hashTypedDataV4(cheque);
-            // console.log("Typed Data Hash From Contract:", typedDataFromContract);
-            expect(typedDataFromContract).to.be.not.reverted;
-
-            // console.log(cheque);
-
-            // Sign Cheque
-            const signature = await _signMessengerCheque(
-                cheque.fromCMAccount,
-                cheque.toCMAccount,
-                cheque.toBot,
-                cheque.counter,
-                cheque.amount,
-                cheque.timestamp,
-                signers.otherAccount1,
+            // Create receiving account (toCMAccount)
+            const tx = await cmAccountManager.createCMAccount(
+                signers.cmAccountAdmin.address,
+                signers.cmAccountPauser.address,
+                signers.cmAccountUpgrader.address,
             );
-            // console.log("Signature From Utils:", signature);
-
-            // Give cheque operator role to signer
-            expect(
-                await cmAccount
-                    .connect(signers.cmAccountAdmin)
-                    .grantRole(await cmAccount.CHEQUE_OPERATOR_ROLE(), signers.otherAccount1.address),
-            ).to.not.be.reverted;
-
-            // Chain ID
-            const chainId = await ethers.provider.getNetwork().then((n) => n.chainId);
-
-            // Domain separator
-            const domainSeparator = calculateDomainSeparatorForChain(chainId);
-
-            // Cheque hash
-            const chequeHash = calculateMessengerChequeHash(cheque);
-            // console.log("Cheque Hash From Utils:", chequeHash);
-
-            // Typed Data Hash
-            const typedDataHash = calculateTypedDataHash(cheque, domainSeparator);
-            // console.log("Typed Data Hash From Utils:", typedDataHash);
-
-            // Verify Cheque
-            const verifyResult = cmAccount.verifyCheque(cheque, signature);
-
-            await expect(await verifyResult).to.be.emit(cmAccount, "ChequeVerified");
-            // .withArgs(cheque, signers.otherAccount1.address, ethers.parseEther("1"));
-
-            const tx = await cmAccount.verifyCheque(cheque, signature);
 
             const receipt = await tx.wait();
 
-            // Parse event to get the CMAccount address (this is the UUPS proxy address)
+            // Parse event to get the CMAccount address
             const event = receipt.logs.find((log) => {
                 try {
-                    return cmAccount.interface.parseLog(log).name === "ChequeVerified";
+                    return cmAccountManager.interface.parseLog(log).name === "CMAccountCreated";
                 } catch (e) {
                     return false;
                 }
             });
 
-            const parsedEvent = cmAccount.interface.parseLog(event);
-            const chequeFromEvent = parsedEvent.args.cheque;
-            const fromBot = parsedEvent.args.signer;
-            const paymentAmount = parsedEvent.args.paymentAmount;
+            const parsedEvent = cmAccountManager.interface.parseLog(event);
+            const toCMAccountAddress = parsedEvent.args.account;
 
-            // console.log(parsedEvent);
-
-            //const { 0: fromBot, 1: paymentAmount } = verifyResult;
-            // console.log("Signer From Contract:", fromBot);
-            // console.log("Payment Amount From Contract:", paymentAmount);
-        });
-    });
-    describe("Cheque Operations", function () {
-        it("Should verify a cheque with a valid signature", async function () {
-            const { cmAccount } = await loadFixture(deployCMAccountWithDepositFixture);
-
+            // Define cheque
             const cheque = {
                 fromCMAccount: await cmAccount.getAddress(),
-                toCMAccount: signers.chequeOperator.address,
+                toCMAccount: toCMAccountAddress,
                 toBot: signers.otherAccount2.address,
                 counter: 1,
                 amount: ethers.parseEther("1"),
@@ -240,11 +171,33 @@ describe("ChequeManager", function () {
         });
 
         it("Should not verify a cheque with an invalid signature", async function () {
-            const { cmAccount } = await loadFixture(deployCMAccountWithDepositFixture);
+            const { cmAccount, cmAccountManager } = await loadFixture(deployCMAccountWithDepositFixture);
 
+            // Create receiving account (toCMAccount)
+            const tx = await cmAccountManager.createCMAccount(
+                signers.cmAccountAdmin.address,
+                signers.cmAccountPauser.address,
+                signers.cmAccountUpgrader.address,
+            );
+
+            const receipt = await tx.wait();
+
+            // Parse event to get the CMAccount address
+            const event = receipt.logs.find((log) => {
+                try {
+                    return cmAccountManager.interface.parseLog(log).name === "CMAccountCreated";
+                } catch (e) {
+                    return false;
+                }
+            });
+
+            const parsedEvent = cmAccountManager.interface.parseLog(event);
+            const toCMAccountAddress = parsedEvent.args.account;
+
+            // Define cheque
             const cheque = {
                 fromCMAccount: await cmAccount.getAddress(),
-                toCMAccount: signers.chequeOperator.address,
+                toCMAccount: toCMAccountAddress,
                 toBot: signers.otherAccount2.address,
                 counter: 1,
                 amount: ethers.parseEther("1"),
@@ -260,16 +213,88 @@ describe("ChequeManager", function () {
             const signature = await signInvalidMessengerCheque(cheque, signers.chequeOperator);
 
             // Verify cheque, should revert and have the wrong address in the event
+            // Because invalid signatures return a different address, we used a predicate to verify that
+            // it's not the expected signer.
             await expect(cmAccount.verifyCheque(cheque, signature))
                 .to.be.revertedWithCustomError(cmAccount, "NotAllowedToSignCheques")
                 .withArgs((addr) => addr !== signers.chequeOperator.address);
         });
-        it("Should cash-in multiple cheques correctly", async function () {
-            const { cmAccount } = await loadFixture(deployCMAccountWithDepositFixture);
 
+        it("Should not verify a cheque with non-allowed signer", async function () {
+            const { cmAccount, cmAccountManager } = await loadFixture(deployCMAccountWithDepositFixture);
+
+            // Create receiving account (toCMAccount)
+            const tx = await cmAccountManager.createCMAccount(
+                signers.cmAccountAdmin.address,
+                signers.cmAccountPauser.address,
+                signers.cmAccountUpgrader.address,
+            );
+
+            const receipt = await tx.wait();
+
+            // Parse event to get the CMAccount address
+            const event = receipt.logs.find((log) => {
+                try {
+                    return cmAccountManager.interface.parseLog(log).name === "CMAccountCreated";
+                } catch (e) {
+                    return false;
+                }
+            });
+
+            const parsedEvent = cmAccountManager.interface.parseLog(event);
+            const toCMAccountAddress = parsedEvent.args.account;
+
+            // Define cheque
             const cheque = {
                 fromCMAccount: await cmAccount.getAddress(),
-                toCMAccount: signers.chequeOperator.address,
+                toCMAccount: toCMAccountAddress,
+                toBot: signers.otherAccount2.address,
+                counter: 1,
+                amount: ethers.parseEther("1"),
+                timestamp: 1721777321,
+            };
+
+            // Be sure that the signer does not have the CHEQUE_OPERATOR_ROLE role
+            const CHEQUE_OPERATOR_ROLE = await cmAccount.CHEQUE_OPERATOR_ROLE();
+            expect(await cmAccountManager.hasRole(CHEQUE_OPERATOR_ROLE, signers.chequeOperator.address)).to.be.false;
+
+            // Sign the cheque. Signature is valid but the signer is not allowed to sign on the `fromCMAccount`
+            const signature = await signMessengerCheque(cheque, signers.chequeOperator);
+
+            // Verify cheque, should revert
+            await expect(cmAccount.verifyCheque(cheque, signature))
+                .to.be.revertedWithCustomError(cmAccount, "NotAllowedToSignCheques")
+                .withArgs(signers.chequeOperator.address);
+        });
+
+        it("Should cash-in multiple cheques correctly", async function () {
+            const { cmAccount, cmAccountManager } = await loadFixture(deployCMAccountWithDepositFixture);
+
+            // Create receiving account (toCMAccount)
+            const tx = await cmAccountManager.createCMAccount(
+                signers.cmAccountAdmin.address,
+                signers.cmAccountPauser.address,
+                signers.cmAccountUpgrader.address,
+            );
+
+            const receipt = await tx.wait();
+
+            // Parse event to get the CMAccount address
+            const event = receipt.logs.find((log) => {
+                try {
+                    return cmAccountManager.interface.parseLog(log).name === "CMAccountCreated";
+                } catch (e) {
+                    return false;
+                }
+            });
+
+            const parsedEvent = cmAccountManager.interface.parseLog(event);
+            const toCMAccountAddress = parsedEvent.args.account;
+
+            // Define cheque
+            const cheque = {
+                fromCMAccount: await cmAccount.getAddress(),
+                toCMAccount: toCMAccountAddress,
                 toBot: signers.otherAccount2.address,
                 counter: 1,
                 amount: ethers.parseEther("0.1"),
@@ -289,12 +314,13 @@ describe("ChequeManager", function () {
             // Cash-in cheque
             const cashInResponse = await cmAccount.cashInCheque(cheque, signature);
 
-            // Check balances
             // CMAccount balance descrease by cheque amount + developerFee
             await expect(await cashInResponse).to.changeEtherBalance(cmAccount, -cheque.amount - developerFee);
+
             // toCMAccount balance increase by cheque amount, we are using regular wallet here instead of another CMAccount
             // TODO: Use a real CMAccount as a receiver (CMAccount CAM receive not implemented yet)
-            await expect(await cashInResponse).to.changeEtherBalance(signers.chequeOperator, cheque.amount);
+            await expect(await cashInResponse).to.changeEtherBalance(toCMAccountAddress, cheque.amount);
+
             // DeveloperWallet balance increase by developerFee
             await expect(await cashInResponse).to.changeEtherBalance(signers.developerWallet, developerFee);
 
@@ -314,13 +340,13 @@ describe("ChequeManager", function () {
             // New cheque with a higher counter and amount
             const cheque2 = {
                 fromCMAccount: await cmAccount.getAddress(),
-                toCMAccount: signers.chequeOperator.address,
+                toCMAccount: toCMAccountAddress,
                 toBot: signers.otherAccount2.address,
                 counter: 100,
                 amount: ethers.parseEther("0.234"),
                 timestamp: 1721777322,
             };
-            234 - 100;
+
             // Sign Cheque
             const signature2 = await signMessengerCheque(cheque2, signers.chequeOperator);
 
@@ -329,17 +355,18 @@ describe("ChequeManager", function () {
             // Cash-in cheque
             const cashInResponse2 = await cmAccount.cashInCheque(cheque2, signature2);
 
-            // Check balances
             // CMAccount balance descrease by (cheque2 amount - cheque amount) + developerFee
             await expect(await cashInResponse2).to.changeEtherBalance(
                 cmAccount,
                 -cheque2.amount + cheque.amount - developerFee2, // Weird calculation but it works
             );
+
             // toCMAccount balance increase by (cheque2 amount - cheque amount)
             await expect(await cashInResponse2).to.changeEtherBalance(
-                signers.chequeOperator,
+                toCMAccountAddress,
                 cheque2.amount - cheque.amount, // new cheque amount minus the lastCashIn amount
             );
+
             // DeveloperWallet balance increase by developerFee
             await expect(await cashInResponse2).to.changeEtherBalance(signers.developerWallet, developerFee2);
 


### PR DESCRIPTION
This PR introduces changes that enforces cheque's `toCMAccount` field to be another CM account address. This is checked using `CMAccountManager.isCMAccount(address account)` function.