### PR TITLE
Switch to access control enumerable

### DIFF
--- a/contracts/account/CMAccount.sol
+++ b/contracts/account/CMAccount.sol
@@ -10,7 +10,7 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 // Access
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
 
 // Cheques
 import "./ChequeManager.sol";
@@ -36,7 +36,7 @@ interface ICMAccountManager {
  */
 contract CMAccount is
     Initializable,
-    AccessControlUpgradeable,
+    AccessControlEnumerableUpgradeable,
     UUPSUpgradeable,
     IERC721Receiver,
     ChequeManager,

--- a/contracts/factory/CMAccountManager.sol
+++ b/contracts/factory/CMAccountManager.sol
@@ -11,7 +11,7 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 // Access
 import "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/extensions/AccessControlEnumerableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 
 // Utils
@@ -32,7 +32,7 @@ interface ICMAccount {
 contract CMAccountManager is
     Initializable,
     PausableUpgradeable,
-    AccessControlUpgradeable,
+    AccessControlEnumerableUpgradeable,
     UUPSUpgradeable,
     ReentrancyGuardUpgradeable
 {

--- a/test/CMAccount.test.js
+++ b/test/CMAccount.test.js
@@ -217,4 +217,30 @@ describe("CMAccount", function () {
             expect(await cmAccount.getDeveloperFeeBp()).to.equal(managerFeeBp);
         });
     });
+
+    describe("Enumerable", function () {
+        it("should get role counts correctly", async function () {
+            const { cmAccountManager, cmAccount } = await loadFixture(deployAndConfigureAllFixture);
+
+            const DEFAULT_ADMIN_ROLE = await cmAccount.DEFAULT_ADMIN_ROLE();
+            const UPGRADER_ROLE = await cmAccount.UPGRADER_ROLE();
+            const BOOKING_OPERATOR_ROLE = await cmAccount.BOOKING_OPERATOR_ROLE();
+
+            expect(await cmAccount.getRoleMemberCount(DEFAULT_ADMIN_ROLE)).to.be.equal(1);
+            expect(await cmAccount.getRoleMemberCount(UPGRADER_ROLE)).to.be.equal(1);
+
+            // Booking operator role is not granted by default
+            expect(await cmAccount.getRoleMemberCount(BOOKING_OPERATOR_ROLE)).to.be.equal(0);
+
+            // Grant booking operator role
+            await expect(
+                cmAccount
+                    .connect(signers.cmAccountAdmin)
+                    .grantRole(await cmAccount.BOOKING_OPERATOR_ROLE(), signers.otherAccount1.address),
+            ).to.not.reverted;
+
+            // Booking operator role is granted, count should be 1
+            expect(await cmAccount.getRoleMemberCount(BOOKING_OPERATOR_ROLE)).to.be.equal(1);
+        });
+    });
 });

--- a/test/CMAccountManager.test.js
+++ b/test/CMAccountManager.test.js
@@ -38,6 +38,37 @@ describe("CMAccountManager", function () {
             expect(await cmAccountManager.getPrefundAmount()).to.be.equal(ethers.parseEther("100"));
         });
 
+        it("should get role counts correctly", async function () {
+            // Set up signers
+            await setupSigners();
+
+            const { cmAccountManager } = await loadFixture(deployCMAccountManagerFixture);
+
+            const DEFAULT_ADMIN_ROLE = await cmAccountManager.DEFAULT_ADMIN_ROLE();
+            const PAUSER_ROLE = await cmAccountManager.PAUSER_ROLE();
+            const UPGRADER_ROLE = await cmAccountManager.UPGRADER_ROLE();
+            const VERSIONER_ROLE = await cmAccountManager.VERSIONER_ROLE();
+            const DEVELOPER_WALLET_ADMIN_ROLE = await cmAccountManager.DEVELOPER_WALLET_ADMIN_ROLE();
+
+            expect(await cmAccountManager.getRoleMemberCount(DEFAULT_ADMIN_ROLE)).to.be.equal(1);
+            expect(await cmAccountManager.getRoleMemberCount(PAUSER_ROLE)).to.be.equal(1);
+            expect(await cmAccountManager.getRoleMemberCount(UPGRADER_ROLE)).to.be.equal(1);
+            expect(await cmAccountManager.getRoleMemberCount(VERSIONER_ROLE)).to.be.equal(1);
+
+            // Developer wallet admin role is not granted by default
+            expect(await cmAccountManager.getRoleMemberCount(DEVELOPER_WALLET_ADMIN_ROLE)).to.be.equal(0);
+
+            // Grant developer wallet role
+            await expect(
+                cmAccountManager
+                    .connect(signers.managerAdmin)
+                    .grantRole(await cmAccountManager.DEVELOPER_WALLET_ADMIN_ROLE(), signers.otherAccount1.address),
+            ).to.not.reverted;
+
+            // Developer wallet admin role is granted, count should be 1
+            expect(await cmAccountManager.getRoleMemberCount(DEVELOPER_WALLET_ADMIN_ROLE)).to.be.equal(1);
+        });
+
         it("should set developer wallet and roles correctly", async function () {
             // Set up signers
             await setupSigners();


### PR DESCRIPTION
Change from `AccessControlUpgradeable` to `AccessControlEnumerableUpgradeable`.

`grantRole()` function's gas consumption jumped from 55k to 115k. But I think it's worth the extra gas as this is not so high frequency operation and enumerable roles enables us to query and loop over all the registered bots and show them in front end UIs easily. 

**Gas consumption table for future reference:**

```
·-------------------------------------------------|---------------------------|-------------|-----------------------------·
|              Solc version: 0.8.24               ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 30000000 gas  │
··················································|···························|·············|······························
|  Methods                                                                                                                │
·····················|····························|·············|·············|·············|···············|··············
|  Contract          ·  Method                    ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
·····················|····························|·············|·············|·············|···············|··············
|  CMAccount         ·  buyBookingToken           ·          -  ·          -  ·     116170  ·            3  ·          -  │
·····················|····························|·············|·············|·············|···············|··············
|  CMAccount         ·  cashInCheque              ·     106779  ·     197891  ·     155478  ·           12  ·          -  │
·····················|····························|·············|·············|·············|···············|··············
|  CMAccount         ·  grantRole                 ·      34499  ·     123591  ·     115069  ·           42  ·          -  │
·····················|····························|·············|·············|·············|···············|··············
|  CMAccount         ·  mintBookingToken          ·     344606  ·     374906  ·     353181  ·            8  ·          -  │
·····················|····························|·············|·············|·············|···············|··············
|  CMAccount         ·  upgradeToAndCall          ·      37912  ·      52209  ·      47443  ·            3  ·          -  │
·····················|····························|·············|·············|·············|···············|··············
|  CMAccount         ·  verifyCheque              ·          -  ·          -  ·      64446  ·            4  ·          -  │
·····················|····························|·············|·············|·············|···············|··············
|  CMAccount         ·  withdraw                  ·          -  ·          -  ·      42320  ·            8  ·          -  │
·····················|····························|·············|·············|·············|···············|··············
|  CMAccountManager  ·  createCMAccount           ·     463462  ·     483362  ·     469432  ·           20  ·          -  │
·····················|····························|·············|·············|·············|···············|··············
|  CMAccountManager  ·  pause                     ·          -  ·          -  ·      52069  ·            2  ·          -  │
·····················|····························|·············|·············|·············|···············|··············
|  CMAccountManager  ·  setAccountImplementation  ·      38552  ·      55652  ·      51377  ·            8  ·          -  │
·····················|····························|·············|·············|·············|···············|··············
|  CMAccountManager  ·  setBookingToken           ·          -  ·          -  ·      55672  ·            3  ·          -  │
·····················|····························|·············|·············|·············|···············|··············
|  CMAccountManager  ·  setDeveloperFeeBp         ·          -  ·          -  ·      35388  ·            3  ·          -  │
·····················|····························|·············|·············|·············|···············|··············
|  CMAccountManager  ·  setDeveloperWallet        ·          -  ·          -  ·      35933  ·            2  ·          -  │
·····················|····························|·············|·············|·············|···············|··············
|  CMAccountManager  ·  setPrefundAmount          ·          -  ·          -  ·      33876  ·            2  ·          -  │
·····················|····························|·············|·············|·············|···············|··············
|  CMAccountManager  ·  unpause                   ·          -  ·          -  ·      30171  ·            1  ·          -  │
·····················|····························|·············|·············|·············|···············|··············
|  Deployments                                    ·                                         ·  % of limit   ·             │
··················································|·············|·············|·············|···············|··············
|  BookingToken                                   ·          -  ·          -  ·    2585858  ·        8.6 %  ·          -  │
··················································|·············|·············|·············|···············|··············
|  CMAccount                                      ·          -  ·          -  ·    2297386  ·        7.7 %  ·          -  │
··················································|·············|·············|·············|···············|··············
|  CMAccountManager                               ·          -  ·          -  ·    2031108  ·        6.8 %  ·          -  │
··················································|·············|·············|·············|···············|··············
|  CMAccountManagerV2                             ·          -  ·          -  ·    2042289  ·        6.8 %  ·          -  │
··················································|·············|·············|·············|···············|··············
|  Dummy                                          ·          -  ·          -  ·     101401  ·        0.3 %  ·          -  │
·-------------------------------------------------|-------------|-------------|-------------|---------------|-------------·
```