### PR TITLE
Fix pragma for all contracts to 0.8.24

### DIFF
--- a/contracts/account/CMAccount.sol
+++ b/contracts/account/CMAccount.sol
@@ -2,7 +2,7 @@
 //
 // Camino Messenger Account Implementation
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/contracts/account/ChequeManager.sol
+++ b/contracts/account/ChequeManager.sol
@@ -2,7 +2,7 @@
 //
 // Camino Messenger Cheque Manager
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.24;
 
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";

--- a/contracts/account/GasMoneyManager.sol
+++ b/contracts/account/GasMoneyManager.sol
@@ -2,7 +2,7 @@
 //
 // Camino Messenger Gas Money Manager
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.24;
 
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";

--- a/contracts/account/ICMAccount.sol
+++ b/contracts/account/ICMAccount.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 interface ICMAccount {
     function initialize(

--- a/contracts/booking-token/BookingToken.sol
+++ b/contracts/booking-token/BookingToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity 0.8.24;
 
 // UUPS Proxy
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/contracts/booking-token/BookingTokenOperator.sol
+++ b/contracts/booking-token/BookingTokenOperator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity 0.8.24;
 
 import "./IBookingToken.sol";
 

--- a/contracts/booking-token/IBookingToken.sol
+++ b/contracts/booking-token/IBookingToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity 0.8.24;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/manager/CMAccountManager.sol
+++ b/contracts/manager/CMAccountManager.sol
@@ -2,7 +2,7 @@
 //
 // Camino Messenger Account Manager
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 // UUPS Proxy
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/contracts/manager/ICMAccountManager.sol
+++ b/contracts/manager/ICMAccountManager.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 interface ICMAccountManager {
     function getAccountImplementation() external view returns (address);

--- a/contracts/manager/test/CMAccountManagerV2.sol
+++ b/contracts/manager/test/CMAccountManagerV2.sol
@@ -6,7 +6,7 @@
  * TESTING ONLY - NOT FOR PRODUCTION
  */
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import { CMAccountManager } from "../CMAccountManager.sol";
 

--- a/contracts/partner/PartnerConfiguration.sol
+++ b/contracts/partner/PartnerConfiguration.sol
@@ -2,7 +2,7 @@
 //
 // Camino Messenger Partner Configuration
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";

--- a/contracts/partner/ServiceRegistry.sol
+++ b/contracts/partner/ServiceRegistry.sol
@@ -2,7 +2,7 @@
 //
 // Camino Messenger Service Registry for Partner Configuration
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";

--- a/contracts/test/Dummy.sol
+++ b/contracts/test/Dummy.sol
@@ -2,7 +2,7 @@
 //
 // TEST CONTRACT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 contract Dummy {
     function getVersion() public pure returns (string memory) {

--- a/contracts/test/NullUSD.sol
+++ b/contracts/test/NullUSD.sol
@@ -2,7 +2,7 @@
 //
 // Null USD Contract for testing purposes
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/utils/KYCUtils.sol
+++ b/contracts/utils/KYCUtils.sol
@@ -2,7 +2,7 @@
 //
 // Camino KYC Utilities
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 interface ICaminoAdmin {
     function getKycState(address account) external view returns (uint256);


### PR DESCRIPTION
This PR fixes pragma version for all contracts to 0.8.24. This should not change the bytecode of previously compiled contract as we were using this version in `hardhat.config.js` from the beginning. 