### PR TITLE
Add new tasks & fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ Messenger](https://camino.network/camino-messenger-sets-the-global-standard-in-t
 
 Below is a table of deployed contracts and their addresses on Camino mainnet.
 
-| Contract                       | Address                                                                                                                                       |
-| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| CMAccountManager               | [0xf9FE1eaAB73a2902136FE7A83E0703338D3b9F1e](https://columbus.caminoscan.com/address/0xf9FE1eaAB73a2902136FE7A83E0703338D3b9F1e?tab=contract) |
-| BookingToken                   | [0xe2b8c92B6519d1A2020dA0A5fBbA99a43A2c0922](https://columbus.caminoscan.com/address/0xe2b8c92B6519d1A2020dA0A5fBbA99a43A2c0922?tab=contract) |
-| BookingTokenOperator (Library) | [0x65C34Ca1FCdF46B60C2b9b8f81475f69086116dD](https://columbus.caminoscan.com/address/0x65C34Ca1FCdF46B60C2b9b8f81475f69086116dD?tab=contract) |
-| CMAccount (Implementation)     | [0x52D94b6ccDa96BE4a99ED9C8D39682D6B4EE4702](https://columbus.caminoscan.com/address/0x52D94b6ccDa96BE4a99ED9C8D39682D6B4EE4702?tab=contract) |
+| Contract                       | Address                                                                                                                              |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| CMAccountManager               | [0xf9FE1eaAB73a2902136FE7A83E0703338D3b9F1e](https://caminoscan.com/address/0xf9FE1eaAB73a2902136FE7A83E0703338D3b9F1e?tab=contract) |
+| BookingToken                   | [0xe2b8c92B6519d1A2020dA0A5fBbA99a43A2c0922](https://caminoscan.com/address/0xe2b8c92B6519d1A2020dA0A5fBbA99a43A2c0922?tab=contract) |
+| BookingTokenOperator (Library) | [0x65C34Ca1FCdF46B60C2b9b8f81475f69086116dD](https://caminoscan.com/address/0x65C34Ca1FCdF46B60C2b9b8f81475f69086116dD?tab=contract) |
+| CMAccount (Implementation)     | [0x52D94b6ccDa96BE4a99ED9C8D39682D6B4EE4702](https://caminoscan.com/address/0x52D94b6ccDa96BE4a99ED9C8D39682D6B4EE4702?tab=contract) |
 
 ## Columbus (testnet) Deployed Contracts
 

--- a/tasks/manager.js
+++ b/tasks/manager.js
@@ -4,6 +4,24 @@ const MANAGER_SCOPE = scope("manager", "CM Account Manager Tasks");
 
 // TODO: Handle transaction failures
 
+const ROLES = [
+    "DEFAULT_ADMIN_ROLE",
+    "PAUSER_ROLE",
+    "UPGRADER_ROLE",
+    "VERSIONER_ROLE",
+    "FEE_ADMIN_ROLE",
+    "DEVELOPER_WALLET_ADMIN_ROLE",
+    "PREFUND_ADMIN_ROLE",
+    "SERVICE_REGISTRY_ADMIN_ROLE",
+    "CMACCOUNT_ROLE",
+];
+
+function bold(text) {
+    const boldCode = "\x1b[1m";
+    const resetCode = "\x1b[0m";
+    return `${boldCode}${text}${resetCode}`;
+}
+
 function getAddressesForNetwork(hre) {
     let addresses;
 
@@ -189,6 +207,16 @@ MANAGER_SCOPE.task("role:members", "List role members")
         console.log(members);
     });
 
+MANAGER_SCOPE.task("role:all", "List all roles").setAction(async (taskArgs, hre) => {
+    const manager = await getManager(hre);
+    for (const role of ROLES) {
+        console.log(`🛡️  ${bold(role)}`);
+        console.log(`${bold("=".repeat(48))}`);
+        await hre.run({ scope: "manager", task: "role:members" }, { role });
+        console.log();
+    }
+});
+
 MANAGER_SCOPE.task("account:list", "List CM Accounts").setAction(async (taskArgs, hre) => {
     await hre.run({ scope: "manager", task: "role:members" }, { role: "CMACCOUNT_ROLE" });
 });
@@ -198,6 +226,26 @@ MANAGER_SCOPE.task("account:set-implementation", "Set CMAccount implementation a
     .setAction(async (taskArgs, hre) => {
         const manager = await getManager(hre);
         const tx = await manager.setAccountImplementation(taskArgs.address);
+        const txReceipt = await tx.wait();
+        console.log("Tx:", txReceipt.hash);
+    });
+
+MANAGER_SCOPE.task("developer:set-fee", "Set developer fee")
+    .addParam("feeBasisPoints", "Developer fee basis points")
+    .setAction(async (taskArgs, hre) => {
+        const manager = await getManager(hre);
+        console.log(`Setting developer fee to ${taskArgs.feeBasisPoints} basis points...`);
+        const tx = await manager.setDeveloperFeeBp(taskArgs.feeBasisPoints);
+        const txReceipt = await tx.wait();
+        console.log("Tx:", txReceipt.hash);
+    });
+
+MANAGER_SCOPE.task("developer:set-address", "Set developer address")
+    .addParam("address", "Developer address")
+    .setAction(async (taskArgs, hre) => {
+        const manager = await getManager(hre);
+        console.log(`Setting developer address to ${taskArgs.address}...`);
+        const tx = await manager.setDeveloperWallet(taskArgs.address);
         const txReceipt = await tx.wait();
         console.log("Tx:", txReceipt.hash);
     });

--- a/tasks/manager.js
+++ b/tasks/manager.js
@@ -1,6 +1,7 @@
 require("@nomicfoundation/hardhat-toolbox");
 
 const MANAGER_SCOPE = scope("manager", "CM Account Manager Tasks");
+const BT_SCOPE = scope("btoken", "Booking Token Tasks");
 
 // TODO: Handle transaction failures
 
@@ -46,15 +47,28 @@ async function getManager(hre) {
     return await ethers.getContractAt("CMAccountManager", addresses["CaminoMessengerModule#ManagerProxy"]);
 }
 
-async function handleRoles(taskArgs, hre, action) {
-    const manager = await getManager(hre);
+async function getBookingToken(hre) {
+    const addresses = getAddressesForNetwork(hre);
+    return await ethers.getContractAt("BookingToken", addresses["CaminoMessengerModule#BookingTokenProxy"]);
+}
+
+async function handleRoles(taskArgs, hre, action, contractName) {
+    let contract;
+
+    if (contractName === "btoken") {
+        contract = await getBookingToken(hre);
+    } else if (contractName === "manager") {
+        contract = await getManager(hre);
+    } else {
+        throw new Error(`Unsupported contract: ${contractName}`);
+    }
 
     console.log(
         `${action === "grantRole" ? "Granting" : "Revoking"} role ${taskArgs.role} for address ${taskArgs.address}...`,
     );
 
-    const role = await manager[taskArgs.role]();
-    const tx = await manager[action](role, taskArgs.address);
+    const role = await contract[taskArgs.role]();
+    const tx = await contract[action](role, taskArgs.address);
     const txReceipt = await tx.wait();
     console.log("Tx:", txReceipt.hash);
 }
@@ -168,14 +182,14 @@ MANAGER_SCOPE.task("role:grant", "Grant role")
     .addParam("role", "Role to grant. Ex: SERVICE_REGISTRY_ADMIN_ROLE")
     .addParam("address", "Address to grant role to")
     .setAction(async (taskArgs, hre) => {
-        await handleRoles(taskArgs, hre, "grantRole");
+        await handleRoles(taskArgs, hre, "grantRole", "manager");
     });
 
 MANAGER_SCOPE.task("role:revoke", "Revoke role")
     .addParam("role", "Role to grant. Ex: SERVICE_REGISTRY_ADMIN_ROLE")
     .addParam("address", "Address to revoke role to")
     .setAction(async (taskArgs, hre) => {
-        await handleRoles(taskArgs, hre, "revokeRole");
+        await handleRoles(taskArgs, hre, "revokeRole", "manager");
     });
 
 MANAGER_SCOPE.task("role:has", "Check if address has role")
@@ -248,6 +262,34 @@ MANAGER_SCOPE.task("developer:set-address", "Set developer address")
         const tx = await manager.setDeveloperWallet(taskArgs.address);
         const txReceipt = await tx.wait();
         console.log("Tx:", txReceipt.hash);
+    });
+
+BT_SCOPE.task("role:grant", "Grant role")
+    .addParam("role", "Role to grant. Ex: MIN_EXPIRATION_ADMIN_ROLE")
+    .addParam("address", "Address to grant role to")
+    .setAction(async (taskArgs, hre) => {
+        console.log(`📅 ${bold("BookingToken")}`);
+        await handleRoles(taskArgs, hre, "grantRole", "btoken");
+    });
+
+BT_SCOPE.task("role:revoke", "Revoke role")
+    .addParam("role", "Role to grant. Ex: MIN_EXPIRATION_ADMIN_ROLE")
+    .addParam("address", "Address to revoke role to")
+    .setAction(async (taskArgs, hre) => {
+        console.log(`📅 ${bold("BookingToken")}`);
+        await handleRoles(taskArgs, hre, "revokeRole", "btoken");
+    });
+
+BT_SCOPE.task("role:has", "Check if address has role")
+    .addParam("role", "Role to check. Ex: MIN_EXPIRATION_ADMIN_ROLE")
+    .addParam("address", "Address to check")
+    .setAction(async (taskArgs, hre) => {
+        const btoken = await getBookingToken(hre);
+        console.log(`📅 ${bold("BookingToken")}`);
+        const role = await btoken[taskArgs.role]();
+        const hasRole = await btoken.hasRole(role, taskArgs.address);
+        console.log(`${taskArgs.address} ${hasRole ? "has" : "does not have"} role ${taskArgs.role}`);
+        console.log(`${hasRole ? "🟢" : "🔴"}`, hasRole);
     });
 
 module.exports = {};


### PR DESCRIPTION
This PR:
- adds `developer:set-fee` and `developer:set-address` sub tasks
- adds `role:all` subtask that lists all the roles with their members
- adds `btoken` task with `role:grant`, `role:revoke`, and `role:has` subtasks
- fixes CaminoScan links in the README for mainnet contract addresses