### PR TITLE
Add Messenger Server CM Account and Bot addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,28 @@ Below is a table of deployed contracts and their addresses on Columbus testnet.
 | BookingTokenOperator (Library) | [0x10133935503b4f958f6dFF783b628ba25aC010E3](https://columbus.caminoscan.com/address/0x10133935503b4f958f6dFF783b628ba25aC010E3?tab=contract) |
 | CMAccount (Implementation)     | [0xCB43DabB6d579d5a6067aB06575601D3D77882CA](https://columbus.caminoscan.com/address/0xCB43DabB6d579d5a6067aB06575601D3D77882CA?tab=contract) |
 
+## Chain4Travel Messenger Server
+
+Chain4Travel is running the first and currently only messenger server.
+
+| Camino Mainnet                       | Address                                      |
+| ------------------------------------ | -------------------------------------------- |
+| Messenger URL                        | `https://dev.messenger.chain4travel.com`     |
+| Messenger CM Account                 | `0x16DFfB3911BB0b1B53eF4d774804381f0B38B5d7` |
+| Messenger Service Bot (`toBot`) Addr | `0xbeb027D2f439805E17EAA16Da26c1FCa68a30232` |
+
+| Columbus Testnet                     | Address                                      |
+| ------------------------------------ | -------------------------------------------- |
+| Messenger URL                        | `https://messenger.chain4travel.com`         |
+| Messenger CM Account                 | `0xF6bA5c68A505559c170dC7a30448Ed64D8b9Bc3B` |
+| Messenger Service Bot (`toBot`) Addr | `0xff6BAC3d972680515cbB59fCB6Db6deB13Eb0E91` |
+
+For network fee cheques, the Camino Messenger Bot should use the values above for:
+
+-   `fromCMAccount`: Partner's CM Account address.
+-   `toCMAccount`: The "**Messenger CM Account**" address from the tables above.
+-   `toBot`: The "**Messenger Service Bot**" address from the tables above.
+
 ## Quickstart
 
 ### Clone the repo and change directory into

--- a/tasks/account.js
+++ b/tasks/account.js
@@ -5,6 +5,23 @@ const ACCOUNT_SCOPE = scope("account", "CM Account Tasks");
 
 // TODO: Get private key from .env or hardhat vars
 
+const ACC_ROLES = [
+    "DEFAULT_ADMIN_ROLE",
+    "UPGRADER_ROLE",
+    "BOT_ADMIN_ROLE",
+    "CHEQUE_OPERATOR_ROLE",
+    "GAS_WITHDRAWER_ROLE",
+    "WITHDRAWER_ROLE",
+    "BOOKING_OPERATOR_ROLE",
+    "SERVICE_ADMIN_ROLE",
+];
+
+function bold(text) {
+    const boldCode = "\x1b[1m";
+    const resetCode = "\x1b[0m";
+    return `${boldCode}${text}${resetCode}`;
+}
+
 function getAddressesForNetwork(hre) {
     let addresses;
 
@@ -133,6 +150,17 @@ ACCOUNT_SCOPE.task("role:members", "List role members")
             console.log(members);
         } catch (error) {
             handleTransactionError(error, cmAccount);
+        }
+    });
+
+ACCOUNT_SCOPE.task("role:all", "List all roles and their members")
+    .addOptionalParam("cmAccount", "CMAccount address", process.env.CMACCOUNT_ADDRESS)
+    .setAction(async (taskArgs, hre) => {
+        for (const role of ACC_ROLES) {
+            console.log(`🛡️  ${bold(role)}`);
+            console.log(`${bold("=".repeat(53))}`);
+            await hre.run({ scope: "account", task: "role:members" }, { role, cmAccount: taskArgs.cmAccount });
+            console.log();
         }
     });
 


### PR DESCRIPTION
This PR:
- adds C4T messenger server CM account and bot addresses for mainnet and testnet to README
- adds `role:all` subtask for the `account` task