### PR TITLE
Remove list for unfinished and non-messenger services

### DIFF
--- a/services/2_remove_non_messenger_services.json
+++ b/services/2_remove_non_messenger_services.json
@@ -1,0 +1,6 @@
+[
+    "cmp.services.network.v1.GetNetworkFeeService",
+    "cmp.services.notification.v1.NotificationService",
+    "cmp.services.partner.v1.GetPartnerConfigurationService",
+    "cmp.services.partner.v2.GetPartnerConfigurationService"
+]


### PR DESCRIPTION
This PR adds a list of services removed from the service registry on CM Account Manager for mainnet and testnet. 

These services are not needed, unfinished or they are only meant to be used between bot and the partner plugin. So, we don't need them on the CM accounts.