### PR TITLE
Reentrancy protection for the accept cancellation func

### DIFF
--- a/test/BookingToken.test.js
+++ b/test/BookingToken.test.js
@@ -1370,8 +1370,8 @@ describe("BookingToken", function () {
 
             // Try to accept the cancellation proposed by the supplier with another account
             await expect(bookingToken.connect(signers.otherAccount3).acceptCancellationProposal(token_id, refundAmount))
-                .to.be.revertedWithCustomError(bookingToken, "NotAuthorizedToAcceptCancellation")
-                .withArgs(0n, signers.otherAccount3.address);
+                .to.be.revertedWithCustomError(bookingToken, "NotCMAccount")
+                .withArgs(signers.otherAccount3.address);
 
             // Accept the supplier's proposal with the distributor cm account
             await expect(
@@ -1391,8 +1391,8 @@ describe("BookingToken", function () {
 
             // Sanity check: Try to accept the cancellation proposed by the owner with another account
             await expect(bookingToken.connect(signers.otherAccount2).acceptCancellationProposal(token_id, refundAmount))
-                .to.be.revertedWithCustomError(bookingToken, "NotAuthorizedToAcceptCancellation")
-                .withArgs(0n, signers.otherAccount2.address);
+                .to.be.revertedWithCustomError(bookingToken, "NotCMAccount")
+                .withArgs(signers.otherAccount2.address);
 
             // Finally, accept the "owner accepted proposal" with the supplier cm account
             const acceptTx = await supplierCMAccount


### PR DESCRIPTION
#### Summary of Changes:
1. **Added Security Enhancements**:
   - The `acceptCancellationProposal` function now includes the `nonReentrant` modifier to prevent reentrancy attacks.
   - Introduced `onlyCMAccount` modifier to ensure only registered CM accounts can execute the cancellation acceptance logic.
   
2. **Improved Functionality and Structure**:
   - Updated internal function logic to check whether the caller is a CMAccount (`msg.sender` is validated against the CMAccountManager contract).
   - Improved refund handling, ensuring refunds are processed _**only after all state changes are made**_, following the checks-effects-interactions pattern.
   - Moved the logic that sets the token status and processes cancellations (burning the token, status update, event emission) before processing the refund for consistency in the flow.
   
3. **Clarified Code Comments**:
   - Updated comments for better clarity, ensuring future developers can easily understand the flow and purpose of various conditions (e.g., specifying early exit conditions for owners, clarifying when supplier-specific logic applies).

#### Updates to Test Cases:
- Modified existing test cases in `BookingToken.test.js` to align with the new `onlyCMAccount` modifier.
- Updated reversion checks to handle the new `NotCMAccount` custom error for non-CM accounts trying to accept cancellation proposals.
  
#### Reason for Changes:
These changes address security concerns by preventing unauthorized or malicious actions through reentrancy attacks. Additionally, they ensure that only verified CM accounts can manage cancellations, aligning with the business logic.

#### Impact:
- These updates improve the contract’s security and clarity.
- The new `onlyCMAccount` modifier restricts access, ensuring that only appropriate parties can interact with the cancellation proposal system.
- Changes should have minimal impact on existing workflows but will require testing of all cancellation proposal acceptance flows to ensure the new security checks behave as expected.
