### PR TITLE
Add reinitializer to update the BookingToken symbol to BToken

### DIFF
--- a/contracts/booking-token/BookingTokenV2.sol
+++ b/contracts/booking-token/BookingTokenV2.sol
@@ -226,6 +226,23 @@ contract BookingTokenV2 is BookingToken {
     error NotAuthorizedToSetCancellable(uint256 tokenId, address caller);
 
     /***************************************************
+     *                  REINITIALIZE                   *
+     ***************************************************/
+
+    /**
+     * @notice This function allows reinitializing the contract to update the name and symbol
+     * @dev Only callable by DEFAULT_ADMIN_ROLE
+     * @param newName New token name
+     * @param newSymbol New token symbol
+     */
+    function reinitializeV2(
+        string memory newName,
+        string memory newSymbol
+    ) public reinitializer(2) onlyRole(DEFAULT_ADMIN_ROLE) {
+        __ERC721_init(newName, newSymbol);
+    }
+
+    /***************************************************
      *                   FUNCTIONS                     *
      ***************************************************/
     /**

--- a/ignition/modules/04_cancellation.js
+++ b/ignition/modules/04_cancellation.js
@@ -31,8 +31,11 @@ const CancellationModule = buildModule("CancellationModule", (m) => {
         id: "BookingTokenV2Impl",
     });
 
+    // Encode the Reinitialize function call for BookingTokenV2
+    const reinitializeV2 = m.encodeFunctionCall(bookingTokenV2, "reinitializeV2", ["BookingToken", "BToken"]);
+
     // Upgrade the BookingToken contract to V2
-    m.call(bookingTokenProxy, "upgradeToAndCall", [bookingTokenV2, "0x"]);
+    m.call(bookingTokenProxy, "upgradeToAndCall", [bookingTokenV2, reinitializeV2]);
 
     return { managerProxy, bookingTokenProxy, bookingTokenOperator, newCMAccountImpl };
 });

--- a/tasks/manager.js
+++ b/tasks/manager.js
@@ -292,4 +292,14 @@ BT_SCOPE.task("role:has", "Check if address has role")
         console.log(`${hasRole ? "🟢" : "🔴"}`, hasRole);
     });
 
+BT_SCOPE.task("status", "Show BookingToken status").setAction(async (taskArgs, hre) => {
+    const btoken = await getBookingToken(hre);
+    console.log(`📅 ${bold("BookingToken")}`);
+    const name = await btoken.name();
+    const symbol = await btoken.symbol();
+    console.log(`${bold("Address")}: ${await btoken.getAddress()}`);
+    console.log(`${bold("Name")}: ${name}`);
+    console.log(`${bold("Symbol")}: ${symbol}`);
+});
+
 module.exports = {};


### PR DESCRIPTION
This PR:
- adds a reinitializer function to BookingTokenV2 that accepts name and symbol to update them
- adds the reinitializer call to the deployment script with name "BookingToken" and symbol "BToken"
- adds `status` subtask for `btoken` task that prints out BookingToken address, name, and symbol of the deployed contract.