### PR TITLE
Add withdraw subtask to account task

### DIFF
--- a/tasks/account.js
+++ b/tasks/account.js
@@ -228,19 +228,47 @@ ACCOUNT_SCOPE.task("withdraw", "Withdraw funds from CMAccount")
     )
     .addParam("recipient", "Recipient address")
     .addParam("amount", "Amount to withdraw")
+    .addOptionalParam("unit", "Unit of amount (CAM/nCAM/aCAM)", "aCAM")
     .setAction(async (taskArgs, hre) => {
         const cmAccount = await getCMAccount(taskArgs.cmAccount);
         console.log("CMAccount:", taskArgs.cmAccount);
 
         try {
+            // Validate unit
+            const validUnits = ["cam", "ncam", "acam"];
+            if (!validUnits.includes(taskArgs.unit.toLowerCase())) {
+                throw new Error(`Invalid unit. Must be one of: ${validUnits.join(", ")}`);
+            }
+
+            // Convert amount to wei based on unit
+            let amountInWei;
+            let hrUnit;
+            const unit = taskArgs.unit.toLowerCase();
+
+            switch (unit) {
+                case "cam":
+                    amountInWei = ethers.parseEther(taskArgs.amount.toString());
+                    hrUnit = "CAM";
+                    break;
+                case "ncam":
+                    amountInWei = ethers.parseUnits(taskArgs.amount.toString(), "gwei");
+                    hrUnit = "nCAM";
+                    break;
+                case "acam":
+                    amountInWei = taskArgs.amount.toString();
+                    hrUnit = "aCAM";
+                    break;
+            }
+
             console.log("Running on", hre.network.name);
             console.log("💸 Withdrawing funds...");
-            console.log("From  :", taskArgs.cmAccount);
-            console.log("To    :", taskArgs.recipient);
-            console.log("Amount:", taskArgs.amount);
+            console.log("From         :", taskArgs.cmAccount);
+            console.log("To           :", taskArgs.recipient);
+            console.log("Amount       :", `${taskArgs.amount} ${hrUnit}`);
+            console.log("Amount (aCAM):", amountInWei.toString());
 
             const signer = new ethers.Wallet(taskArgs.privateKey, ethers.provider);
-            const tx = await cmAccount.connect(signer).withdraw(taskArgs.recipient, taskArgs.amount);
+            const tx = await cmAccount.connect(signer).withdraw(taskArgs.recipient, amountInWei);
             const receipt = await tx.wait();
             console.log("Tx:", receipt.hash);
         } catch (error) {

--- a/tasks/account.js
+++ b/tasks/account.js
@@ -234,6 +234,11 @@ ACCOUNT_SCOPE.task("withdraw", "Withdraw funds from CMAccount")
 
         try {
             console.log("Running on", hre.network.name);
+            console.log("💸 Withdrawing funds...");
+            console.log("From  :", taskArgs.cmAccount);
+            console.log("To    :", taskArgs.recipient);
+            console.log("Amount:", taskArgs.amount);
+
             const signer = new ethers.Wallet(taskArgs.privateKey, ethers.provider);
             const tx = await cmAccount.connect(signer).withdraw(taskArgs.recipient, taskArgs.amount);
             const receipt = await tx.wait();

--- a/tasks/account.js
+++ b/tasks/account.js
@@ -219,6 +219,30 @@ ACCOUNT_SCOPE.task("create", "Create CMAccount")
         }
     });
 
+ACCOUNT_SCOPE.task("withdraw", "Withdraw funds from CMAccount")
+    .addOptionalParam("privateKey", "Private key to use, default: CMACCOUNT_PK env variable", process.env.CMACCOUNT_PK)
+    .addOptionalParam(
+        "cmAccount",
+        "CMAccount address, default: CMACCOUNT_ADDRESS env variable",
+        process.env.CMACCOUNT_ADDRESS,
+    )
+    .addParam("recipient", "Recipient address")
+    .addParam("amount", "Amount to withdraw")
+    .setAction(async (taskArgs, hre) => {
+        const cmAccount = await getCMAccount(taskArgs.cmAccount);
+        console.log("CMAccount:", taskArgs.cmAccount);
+
+        try {
+            console.log("Running on", hre.network.name);
+            const signer = new ethers.Wallet(taskArgs.privateKey, ethers.provider);
+            const tx = await cmAccount.connect(signer).withdraw(taskArgs.recipient, taskArgs.amount);
+            const receipt = await tx.wait();
+            console.log("Tx:", receipt.hash);
+        } catch (error) {
+            handleTransactionError(error, cmAccount);
+        }
+    });
+
 ACCOUNT_SCOPE.task("bot:add", "Add bot to the CMAccount")
     .addOptionalParam("privateKey", "Private key to use, default: CMACCOUNT_PK env variable", process.env.CMACCOUNT_PK)
     .addOptionalParam(


### PR DESCRIPTION
This PR adds a `withdraw` subtask for the `account` task that can be used to call `withdraw` function of a CM Account.