### PR TITLE
Adding Camino Messenger Account Setup Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,11 @@ Ethers.js, check out the [`test/ChequeManager.test.js`](test/ChequeManager.test.
 
 ## Camino Messenger Account Setup
 
-**Note:** This guide is for development purposes only. For officially registered CM Accounts, please visit [Camino Messenger Partners](https://suite.camino.network/partners) and select **Register As A Partner**.
+> [!WARNING]
+> This guide is for development purposes only. For officially registered
+> CM Accounts, please visit [Camino Messenger
+> Partners](https://suite.camino.network/partners) and select "**Register As A
+> Partner**" from top right.
 
 ### Prerequisites
 
@@ -468,72 +472,136 @@ Before you begin, ensure you have completed the following steps:
 
 - **Compile the Contracts:** Make sure all contracts are compiled successfully.
 - **KYC Verification:** Complete KYC for your wallet, as deploying a new contract (your CM Account) requires it.
-- **Fund Your Wallet:** Use the faucet to fund your wallet. Your new CM Account will be initially credited with 100 CAM tokens, so please ensure that your wallet contains more than 100 CAM tokens.
+- **Fund Your Wallet:** Use [the faucet](https://docs.camino.network/developer/guides/how-to-deploy-a-smart-contract/#3-request-funds-from-the-discord-faucet) to fund your wallet. Your new CM Account will be initially credited with 100 CAM tokens, so please ensure that your wallet contains more than 100 CAM tokens.
 
 ### Creating a CM Account
 
 To create your CM Account, run the following command:
 
-`yarn hardhat account create --private-key <PrivateKeyValue> --network columbus`
+```
+yarn hardhat account create --private-key <PrivateKeyValue> --network columbus
+```
+
+<details>
+<summary>Example output:</summary>
+
+```
+yarn run v1.22.22
+$ /hgst/work/github.com/chain4travel/camino-messenger-contracts/node_modules/.bin/hardhat account create --private-key <private-key-deducted> --network columbus
+Running on columbus
+Creating CMAccount...
+Signer: 0xFe77dcE375C3814F15F8035bCAC1A791D3dCdf21
+Tx: 0x9b3bf383c7415cad9c442b60ff051c7c6467f5393e5b7a3c56a2aae475cc8f2d
+CMAccount Address: 0xe7C3AAd26fA667a2dc51A4B3c56f8919574b275A
+Done in 2.86s.
+```
+
+</details>
+
+> [!TIP]
+> You can also export variables for private key and CM Account address for
+> the commands used below in the document, instead of specifying them from the CLI.
+>
+> ```
+> export CMACCOUNT_PK=0x...
+> ```
+>
+> ```
+> export CMACCOUNT_ADDRESS=0x...
+> ```
 
 #### Command Parameters
 
-- **--private-key:**  
-  Enter the static private key of your wallet (omit the `0x` prefix).
+- **`--private-key`:**  
+  Enter the static private key of your wallet.
 
-- **--network:**  
-  Specify the network where you wish to create your account (as configured in your `hardhat.config.json`).
+- **`--network`:**  
+  Specify the network where you wish to create your account (as configured in your `hardhat.config.json`). For development purposes it should be `columbus`.
 
 In the output of the command, you will get a new CM Account address, that you need to save and use in the following steps.
 
 ### Registering Your Bot
 
-After creating your CM Account, you need to register the address of your bot. Execute the following command:
+After creating your CM Account, you need to register the address of your bot on the
+CM Account so it can sign cheques. Execute the following command:
 
-`yarn hardhat account bot:add --cm-account <CMAccountAddress> --private-key <PrivateKeyValue> --bot <BotAddress> --network columbus`
+```
+yarn hardhat account bot:add --cm-account <CMAccountAddress> --private-key <PrivateKeyValue> --bot <BotAddress> --network columbus
+```
+
+<details>
+<summary>Example output:</summary>
+
+```
+yarn run v1.22.22
+$ /hgst/work/github.com/chain4travel/camino-messenger-contracts/node_modules/.bin/hardhat account bot:add --cm-account 0xe7C3AAd26fA667a2dc51A4B3c56f8919574b275A --private-key <private-key-deducted> --network columbus --bot 0xd41786599F2B225A5A1eA35cDc4A2a6Fa9E92BeA
+CMAccount: 0xe7C3AAd26fA667a2dc51A4B3c56f8919574b275A
+Bot: 0xd41786599F2B225A5A1eA35cDc4A2a6Fa9E92BeA
+Gas: 0 (This amount will be transferred from the CMAccount to the bot address)
+Adding bot to CMAccount...
+Signer: 0xFe77dcE375C3814F15F8035bCAC1A791D3dCdf21
+Tx: 0x24421b26f36caadcdb007c1a5d010416b8889586c36471d399a3ab367ff967a4
+Done in 2.16s.
+```
+
+</details>
 
 #### Command Parameters
 
-- **--cm-account:**  
+- **`--cm-account`:**  
   The EVM contract address of your newly created CM Account.
-
-- **--private-key:**  
+- **`--private-key`:**  
   The static private key of the wallet used for creating the CM Account (without the `0x` prefix).
-
-- **--bot:**  
+- **`--bot`:**  
   The address of the bot you are registering. Ensure that this address is your C-chain address and not the same as your CM Account wallet.
-
-- **--network:**  
+- **`--network`:**  
   Specify the network (as configured in your `hardhat.config.json`).
 
 ### Registering Services
 
 With your CM Account and bot registered, you can now add supported services. For example, to register the Ping Service, use the following command:
 
-`yarn hardhat account service:add --cm-account  <CMAccountAddress> --private-key <PrivateKeyValue> --service-name cmp.services.ping.v1.PingService --fee 10 --network columbus`
+```
+yarn hardhat account service:add --cm-account  <CMAccountAddress> --private-key <PrivateKeyValue> --service-name cmp.services.ping.v1.PingService --fee 10 --network columbus
+```
+
+<details>
+<summary>Example output:</summary>
+
+```
+yarn run v1.22.22
+$ /hgst/work/github.com/chain4travel/camino-messenger-contracts/node_modules/.bin/hardhat account service:add --service-name cmp.services.ping.v1.PingService --fee 10 --cm-account 0xe7C3AAd26fA667a2dc51A4B3c56f8919574b275A --private-key <private-key-deducted> --network columbus
+CMAccount: 0xe7C3AAd26fA667a2dc51A4B3c56f8919574b275A
+Service Name: cmp.services.ping.v1.PingService
+Fee: 10
+Restricted Rate: false
+Capabilities: undefined
+Adding service to CMAccount...
+Signer: 0xFe77dcE375C3814F15F8035bCAC1A791D3dCdf21
+Tx: 0xe84c6e7e8bfa90f9a35a4534add7b182a5b2240c6b0c1f2433cfad5156b4628d
+Done in 2.11s.
+```
+
+</details>
 
 #### Command Parameters
 
-- **--cm-account:**  
+- **`--cm-account`:**  
   The EVM contract address of your CM Account.
-
-- **--private-key:**  
+- **`--private-key`:**  
   The static private key of the wallet used to create your CM Account (without the `0x` prefix).
-
-- **--service-name:**  
+- **`--service-name`:**  
   The full-service name to register. For a complete list of supported services, consult the [Camino Messenger Protocol documentation](https://buf.build/chain4travel/camino-messenger-protocol/docs).
-
-- **--fee:**  
+- **`--fee`:**  
   The service fee associated with your service.
-
-- **--network:**  
+- **`--network`:**  
   Specify the network (as configured in your `hardhat.config.json`).
 
-## Summary
+### Summary
 
 Following these steps, you will have:
 
-1. Created your CM Account through the deployment of an EVM smart contract.
+1. Created your CM Account.
 2. Registered your bot with the newly created CM Account.
 3. Added and configured services to enhance your account's capabilities.
 

--- a/README.md
+++ b/README.md
@@ -470,8 +470,8 @@ Ethers.js, check out the [`test/ChequeManager.test.js`](test/ChequeManager.test.
 
 Before you begin, ensure you have completed the following steps:
 
-- **Compile the Contracts:** Make sure all contracts are compiled successfully.
-- **KYC Verification:** Complete KYC for your wallet, as deploying a new contract (your CM Account) requires it.
+- **Compile the Contracts:** Make sure all contracts are compiled successfully. (`yarn compile --force`)
+- **KYC Verification:** Complete [the KYC process](https://docs.camino.network/guides/kyc) for your wallet, as deploying a new contract (your CM Account) requires it.
 - **Fund Your Wallet:** Use [the faucet](https://docs.camino.network/developer/guides/how-to-deploy-a-smart-contract/#3-request-funds-from-the-discord-faucet) to fund your wallet. Your new CM Account will be initially credited with 100 CAM tokens, so please ensure that your wallet contains more than 100 CAM tokens.
 
 ### Creating a CM Account
@@ -499,8 +499,11 @@ Done in 2.86s.
 </details>
 
 > [!TIP]
-> You can also export variables for private key and CM Account address for
-> the commands used below in the document, instead of specifying them from the CLI.
+> You can also export variables, instead of specifying them from the CLI, for
+> private key and CM Account address for the commands used below in this document.
+>
+> You can use these commands below to set the variables and then omit the
+> `--private-key` and `--cm-account` arguments.
 >
 > ```
 > export CMACCOUNT_PK=0x...
@@ -516,7 +519,7 @@ Done in 2.86s.
   Enter the static private key of your wallet.
 
 - **`--network`:**  
-  Specify the network where you wish to create your account (as configured in your `hardhat.config.json`). For development purposes it should be `columbus`.
+  Specify the network where you wish to create your account (as configured in the `hardhat.config.json`). For development purposes it should be `columbus`.
 
 In the output of the command, you will get a new CM Account address, that you need to save and use in the following steps.
 
@@ -555,7 +558,7 @@ Done in 2.16s.
 - **`--bot`:**  
   The address of the bot you are registering. Ensure that this address is your C-chain address and not the same as your CM Account wallet.
 - **`--network`:**  
-  Specify the network (as configured in your `hardhat.config.json`).
+  Specify the network (as configured in the `hardhat.config.json`).
 
 ### Registering Services
 
@@ -593,9 +596,9 @@ Done in 2.11s.
 - **`--service-name`:**  
   The full-service name to register. For a complete list of supported services, consult the [Camino Messenger Protocol documentation](https://buf.build/chain4travel/camino-messenger-protocol/docs).
 - **`--fee`:**  
-  The service fee associated with your service.
+  The service fee associated with your service in `aCAM` (`wei` in EVM terms).
 - **`--network`:**  
-  Specify the network (as configured in your `hardhat.config.json`).
+  Specify the network (as configured in the `hardhat.config.json`).
 
 ### Summary
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Chain4Travel is running the first and currently only messenger server.
 
 For network fee cheques, the Camino Messenger Bot should use the values above for:
 
-- `fromCMAccount`: Partner's CM Account address.
-- `toCMAccount`: The "**Messenger CM Account**" address from the tables above.
-- `toBot`: The "**Messenger Service Bot**" address from the tables above.
+-   `fromCMAccount`: Partner's CM Account address.
+-   `toCMAccount`: The "**Messenger CM Account**" address from the tables above.
+-   `toBot`: The "**Messenger Service Bot**" address from the tables above.
 
 ## Quickstart
 
@@ -244,7 +244,7 @@ and verified. For more info see: https://eips.ethereum.org/EIPS/eip-712
 
 #### Cheque Typehash, Domain Typehash, and Domain Separator
 
-- **Cheque Typehash:** This is the `keccak256` hash of the MessengerCheque struct type.
+-   **Cheque Typehash:** This is the `keccak256` hash of the MessengerCheque struct type.
 
     ```js
     function calculateMessengerChequeTypeHash() {
@@ -257,7 +257,7 @@ and verified. For more info see: https://eips.ethereum.org/EIPS/eip-712
     }
     ```
 
-- **Domain Typehash:** This is the `keccak256` hash of the EIP-712 domain type.
+-   **Domain Typehash:** This is the `keccak256` hash of the EIP-712 domain type.
 
     ```js
     function calculateDomainTypeHash() {
@@ -268,8 +268,8 @@ and verified. For more info see: https://eips.ethereum.org/EIPS/eip-712
     }
     ```
 
-- **Domain Separator:** This is a hash that combines the domain typehash with the
-  name, version, and chain ID of the domain.
+-   **Domain Separator:** This is a hash that combines the domain typehash with the
+    name, version, and chain ID of the domain.
 
     ```js
     function calculateDomainSeparator(domainName, domainVersion, chainId) {
@@ -426,11 +426,11 @@ function verifyCheque(
 This function does not only verify that the signer of the cheque is a registered bot
 on the CM Account, but also other verifications like:
 
-- If the `fromCMAccount` is the contract itself
-- If the address of `toCMAccount` is a registered CM Account on the manager
-- If `expiresAt` timestamp is bigger then `block.timestamp`
-- Last counter and last amount recorded on the contract are lower then the cheque's
-- If the `toBot` address has the required role (`CHEQUE_OPERATOR_ROLE`)
+-   If the `fromCMAccount` is the contract itself
+-   If the address of `toCMAccount` is a registered CM Account on the manager
+-   If `expiresAt` timestamp is bigger then `block.timestamp`
+-   Last counter and last amount recorded on the contract are lower then the cheque's
+-   If the `toBot` address has the required role (`CHEQUE_OPERATOR_ROLE`)
 
 So, to only verify if cheque's signature is valid, without doing the verifications
 above (which can only be done on-chain), you can use the examples below.
@@ -466,9 +466,9 @@ Ethers.js, check out the [`test/ChequeManager.test.js`](test/ChequeManager.test.
 
 Before you begin, ensure you have completed the following steps:
 
-- **Compile the Contracts:** Make sure all contracts are compiled successfully.
-- **KYC Verification:** Complete KYC for your wallet, as deploying a new contract (your CM Account) requires it.
-- **Fund Your Wallet:** Use the faucet to fund your wallet. Your new CM Account will be initially credited with 100 CAM tokens, so please make sure to have > 100CAM.
+-   **Compile the Contracts:** Make sure all contracts are compiled successfully.
+-   **KYC Verification:** Complete KYC for your wallet, as deploying a new contract (your CM Account) requires it.
+-   **Fund Your Wallet:** Use the faucet to fund your wallet. Your new CM Account will be initially credited with 100 CAM tokens, so please make sure to have > 100CAM.
 
 ### Creating a CM Account
 
@@ -478,11 +478,11 @@ To create your CM Account, run the following command:
 
 #### Command Parameters
 
-- **--private-key:**  
-  Enter the static private key of your wallet (omit the `0x` prefix).
+-   **--private-key:**  
+    Enter the static private key of your wallet (omit the `0x` prefix).
 
-- **--network:**  
-  Specify the network where you wish to create your account (as configured in your `hardhat.config.json`).
+-   **--network:**  
+    Specify the network where you wish to create your account (as configured in your `hardhat.config.json`).
 
 In the output of the command, you will get a new CM Account address, that you need to save and use in the following steps.
 
@@ -494,17 +494,17 @@ After creating your CM Account, you need to register the address of your bot. Ex
 
 #### Command Parameters
 
-- **--cm-account:**  
-  The EVM contract address of your newly created CM Account.
+-   **--cm-account:**  
+    The EVM contract address of your newly created CM Account.
 
-- **--private-key:**  
-  The static private key of the wallet used for creating the CM Account (without the `0x` prefix).
+-   **--private-key:**  
+    The static private key of the wallet used for creating the CM Account (without the `0x` prefix).
 
-- **--bot:**  
-  The address of the bot you are registering. Ensure that this address is your C-chain address and not the same as your CM Account wallet.
+-   **--bot:**  
+    The address of the bot you are registering. Ensure that this address is your C-chain address and not the same as your CM Account wallet.
 
-- **--network:**  
-  Specify the network (as configured in your `hardhat.config.json`).
+-   **--network:**  
+    Specify the network (as configured in your `hardhat.config.json`).
 
 ### Registering Services
 
@@ -514,20 +514,21 @@ With your CM Account and bot registered, you can now add supported services. For
 
 #### Command Parameters
 
-- **--cm-account:**  
-  The EVM contract address of your CM Account.
+-   **--cm-account:**  
+    The EVM contract address of your CM Account.
 
-- **--private-key:**  
-  The static private key of the wallet used to create your CM Account (without the `0x` prefix).
+-   **--private-key:**  
+    The static private key of the wallet used to create your CM Account (without the `0x` prefix).
 
-- **--service-name:**  
-  The full service name to register. For a complete list of supported services, consult the [Camino Messenger Protocol documentation](https://buf.build/chain4travel/camino-messenger-protocol/docs).
+-   **--service-name:**  
+    The full service name to register. For a complete list of supported services, consult the [Camino Messenger Protocol documentation](https://buf.build/chain4travel/camino-messenger-protocol/docs).
 
-- **--fee:**  
-  The service fee associated with your service.
+-   **--fee:**  
+    The service fee associated with your service.
 
-- **--network:**  
-  Specify the network (as configured in your `hardhat.config.json`).
+-   **--network:**  
+    Specify the network (as configured in your `hardhat.config.json`).
+
 ## Summary
 
 Following these steps, you will have:

--- a/README.md
+++ b/README.md
@@ -515,11 +515,8 @@ Done in 2.86s.
 
 #### Command Parameters
 
-- **`--private-key`:**  
-  Enter the static private key of your wallet.
-
-- **`--network`:**  
-  Specify the network where you wish to create your account (as configured in the `hardhat.config.json`). For development purposes it should be `columbus`.
+- **`--private-key`:** Enter the static private key of your wallet.
+- **`--network`:** Specify the network where you wish to create your account (as configured in the `hardhat.config.json`). For development purposes it should be `columbus`.
 
 In the output of the command, you will get a new CM Account address, that you need to save and use in the following steps.
 
@@ -551,14 +548,10 @@ Done in 2.16s.
 
 #### Command Parameters
 
-- **`--cm-account`:**  
-  The EVM contract address of your newly created CM Account.
-- **`--private-key`:**  
-  The static private key of the wallet used for creating the CM Account (without the `0x` prefix).
-- **`--bot`:**  
-  The address of the bot you are registering. Ensure that this address is your C-chain address and not the same as your CM Account wallet.
-- **`--network`:**  
-  Specify the network (as configured in the `hardhat.config.json`).
+- **`--cm-account`:** The EVM contract address of your newly created CM Account.
+- **`--private-key`:** The static private key of the wallet used for creating the CM Account (without the `0x` prefix).
+- **`--bot`:** The address of the bot you are registering. Ensure that this address is your C-chain address and not the same as your CM Account wallet.
+- **`--network`:** Specify the network (as configured in the `hardhat.config.json`).
 
 ### Registering Services
 
@@ -589,16 +582,11 @@ Done in 2.11s.
 
 #### Command Parameters
 
-- **`--cm-account`:**  
-  The EVM contract address of your CM Account.
-- **`--private-key`:**  
-  The static private key of the wallet used to create your CM Account (without the `0x` prefix).
-- **`--service-name`:**  
-  The full-service name to register. For a complete list of supported services, consult the [Camino Messenger Protocol documentation](https://buf.build/chain4travel/camino-messenger-protocol/docs). (You can also check the service names here in the [services](./services/) folder)
-- **`--fee`:**  
-  The service fee associated with your service in `aCAM` (`wei` in EVM terms).
-- **`--network`:**  
-  Specify the network (as configured in the `hardhat.config.json`).
+- **`--cm-account`:** The EVM contract address of your CM Account.
+- **`--private-key`:** The static private key of the wallet used to create your CM Account (without the `0x` prefix).
+- **`--service-name`:** The full-service name to register. For a complete list of supported services, consult the [Camino Messenger Protocol documentation](https://buf.build/chain4travel/camino-messenger-protocol/docs). (You can also check the service names here in the [services](./services/) folder)
+- **`--fee`:** The service fee associated with your service in `aCAM` (`wei` in EVM terms).
+- **`--network`:** Specify the network (as configured in the `hardhat.config.json`).
 
 ### Summary
 

--- a/README.md
+++ b/README.md
@@ -466,6 +466,14 @@ Ethers.js, check out the [`test/ChequeManager.test.js`](test/ChequeManager.test.
 > Partners](https://suite.camino.network/partners) and select "**Register As A
 > Partner**" from top right.
 
+To set up your Camino Messenger Account (CM Account) for use with the Camino Messenger Bot, you need to:
+
+1. Create a CM Account
+2. Register your bot on your CM Account
+3. Register the services you provide on your CM Account
+
+Follow the steps below to complete this process.
+
 ### Prerequisites
 
 Before you begin, ensure you have completed the following steps:

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ Before you begin, ensure you have completed the following steps:
 
 -   **Compile the Contracts:** Make sure all contracts are compiled successfully.
 -   **KYC Verification:** Complete KYC for your wallet, as deploying a new contract (your CM Account) requires it.
--   **Fund Your Wallet:** Use the faucet to fund your wallet. Your new CM Account will be initially credited with 100 CAM tokens, so please make sure to have > 100CAM.
+-   **Fund Your Wallet:** Use the faucet to fund your wallet. Your new CM Account will be initially credited with 100 CAM tokens, so please ensure that your wallet contains more than 100 CAM tokens.
 
 ### Creating a CM Account
 
@@ -508,7 +508,7 @@ After creating your CM Account, you need to register the address of your bot. Ex
 
 ### Registering Services
 
-With your CM Account and bot registered, you can now add supported services. For example, to register the Ping Service, use the following command:``
+With your CM Account and bot registered, you can now add supported services. For example, to register the Ping Service, use the following command:
 
 `yarn hardhat account service:add --cm-account  <CMAccountAddress> --private-key <PrivateKeyValue> --service-name cmp.services.ping.v1.PingService --fee 10 --network columbus`
 
@@ -521,7 +521,7 @@ With your CM Account and bot registered, you can now add supported services. For
     The static private key of the wallet used to create your CM Account (without the `0x` prefix).
 
 -   **--service-name:**  
-    The full service name to register. For a complete list of supported services, consult the [Camino Messenger Protocol documentation](https://buf.build/chain4travel/camino-messenger-protocol/docs).
+    The full-service name to register. For a complete list of supported services, consult the [Camino Messenger Protocol documentation](https://buf.build/chain4travel/camino-messenger-protocol/docs).
 
 -   **--fee:**  
     The service fee associated with your service.

--- a/README.md
+++ b/README.md
@@ -594,7 +594,7 @@ Done in 2.11s.
 - **`--private-key`:**  
   The static private key of the wallet used to create your CM Account (without the `0x` prefix).
 - **`--service-name`:**  
-  The full-service name to register. For a complete list of supported services, consult the [Camino Messenger Protocol documentation](https://buf.build/chain4travel/camino-messenger-protocol/docs).
+  The full-service name to register. For a complete list of supported services, consult the [Camino Messenger Protocol documentation](https://buf.build/chain4travel/camino-messenger-protocol/docs). (You can also check the service names here in the [services](./services/) folder)
 - **`--fee`:**  
   The service fee associated with your service in `aCAM` (`wei` in EVM terms).
 - **`--network`:**  

--- a/README.md
+++ b/README.md
@@ -457,3 +457,83 @@ Ethers.js, check out the [`test/ChequeManager.test.js`](test/ChequeManager.test.
 #### Python
 
 **TODO:** WIP
+
+## Camino Messenger Account Setup
+
+**Note:** This guide is for development purposes only. For officially registered CM Accounts, please visit [Camino Messenger Partners](https://suite.camino.network/partners) and select **Register As A Partner**.
+
+### Prerequisites
+
+Before you begin, ensure you have completed the following steps:
+
+- **Compile the Contracts:** Make sure all contracts are compiled successfully.
+- **KYC Verification:** Complete KYC for your wallet, as deploying a new contract (your CM Account) requires it.
+- **Fund Your Wallet:** Use the faucet to fund your wallet. Your new CM Account will be initially credited with 100 CAM tokens, so please make sure to have > 100CAM.
+
+### Creating a CM Account
+
+To create your CM Account, run the following command:
+
+`yarn hardhat account create --private-key <PrivateKeyValue> --network columbus`
+
+#### Command Parameters
+
+- **--private-key:**  
+  Enter the static private key of your wallet (omit the `0x` prefix).
+
+- **--network:**  
+  Specify the network where you wish to create your account (as configured in your `hardhat.config.json`).
+
+In the output of the command, you will get a new CM Account address, that you need to save and use in the following steps.
+
+### Registering Your Bot
+
+After creating your CM Account, you need to register the address of your bot. Execute the following command:
+
+`yarn hardhat account bot:add --cm-account <CMAccountAddress> --private-key <PrivateKeyValue> --bot <BotAddress> --network columbus`
+
+#### Command Parameters
+
+- **--cm-account:**  
+  The EVM contract address of your newly created CM Account.
+
+- **--private-key:**  
+  The static private key of the wallet used for creating the CM Account (without the `0x` prefix).
+
+- **--bot:**  
+  The address of the bot you are registering. Ensure that this address is your C-chain address and not the same as your CM Account wallet.
+
+- **--network:**  
+  Specify the network (as configured in your `hardhat.config.json`).
+
+### Registering Services
+
+With your CM Account and bot registered, you can now add supported services. For example, to register the Ping Service, use the following command:``
+
+`yarn hardhat account service:add --cm-account  <CMAccountAddress> --private-key <PrivateKeyValue> --service-name cmp.services.ping.v1.PingService --fee 10 --network columbus`
+
+#### Command Parameters
+
+- **--cm-account:**  
+  The EVM contract address of your CM Account.
+
+- **--private-key:**  
+  The static private key of the wallet used to create your CM Account (without the `0x` prefix).
+
+- **--service-name:**  
+  The full service name to register. For a complete list of supported services, consult the [Camino Messenger Protocol documentation](https://buf.build/chain4travel/camino-messenger-protocol/docs).
+
+- **--fee:**  
+  The service fee associated with your service.
+
+- **--network:**  
+  Specify the network (as configured in your `hardhat.config.json`).
+## Summary
+
+Following these steps, you will have:
+
+1. Created your CM Account through the deployment of an EVM smart contract.
+2. Registered your bot with the newly created CM Account.
+3. Added and configured services to enhance your account's capabilities.
+
+You can now add your CM Account address to the Camino Messenger Bot configuration and start running the bot.

--- a/README.md
+++ b/README.md
@@ -470,9 +470,9 @@ Ethers.js, check out the [`test/ChequeManager.test.js`](test/ChequeManager.test.
 
 Before you begin, ensure you have completed the following steps:
 
-- **Compile the Contracts:** Make sure all contracts are compiled successfully. (`yarn compile --force`)
-- **KYC Verification:** Complete [the KYC process](https://docs.camino.network/guides/kyc) for your wallet, as deploying a new contract (your CM Account) requires it.
-- **Fund Your Wallet:** Use [the faucet](https://docs.camino.network/developer/guides/how-to-deploy-a-smart-contract/#3-request-funds-from-the-discord-faucet) to fund your wallet. Your new CM Account will be initially credited with 100 CAM tokens, so please ensure that your wallet contains more than 100 CAM tokens.
+- **Compile the Contracts:** Ensure all contracts are successfully compiled. (`yarn compile --force`)
+- **KYC Verification:** Complete [the KYC process](https://docs.camino.network/guides/kyc) for your wallet, as deploying a new contract (your CM Account) requires verification.
+- **Fund Your Wallet:** Use [the faucet](https://docs.camino.network/developer/guides/how-to-deploy-a-smart-contract/#3-request-funds-from-the-discord-faucet) to fund your wallet. Your new CM Account will initially needs to receive 100 CAM tokens, so ensure your wallet contains more than 100 CAM tokens.
 
 ### Creating a CM Account
 
@@ -499,11 +499,11 @@ Done in 2.86s.
 </details>
 
 > [!TIP]
-> You can also export variables, instead of specifying them from the CLI, for
-> private key and CM Account address for the commands used below in this document.
+> Instead of specifying your private key and CM Account address from the CLI,
+> you can export them as variables.
 >
-> You can use these commands below to set the variables and then omit the
-> `--private-key` and `--cm-account` arguments.
+> Use these commands to set the variables, and then you can omit the `--private-key`
+> and `--cm-account` arguments from the `yarn hardhat account` commands below:
 >
 > ```
 > export CMACCOUNT_PK=0x...
@@ -516,14 +516,14 @@ Done in 2.86s.
 #### Command Parameters
 
 - **`--private-key`:** Enter the static private key of your wallet.
-- **`--network`:** Specify the network where you wish to create your account (as configured in the `hardhat.config.json`). For development purposes it should be `columbus`.
+- **`--network`:** Specify the network where you wish to create your account (as configured in the `hardhat.config.json`). For development purposes, use `columbus`.
 
-In the output of the command, you will get a new CM Account address, that you need to save and use in the following steps.
+The command output will provide a new CM Account address that you must save for use in the following steps.
 
 ### Registering Your Bot
 
 After creating your CM Account, you need to register the address of your bot on the
-CM Account so it can sign cheques. Execute the following command:
+CM Account to enable it to sign cheques. Execute the following command:
 
 ```
 yarn hardhat account bot:add --cm-account <CMAccountAddress> --private-key <PrivateKeyValue> --bot <BotAddress> --network columbus
@@ -549,7 +549,7 @@ Done in 2.16s.
 #### Command Parameters
 
 - **`--cm-account`:** The EVM contract address of your newly created CM Account.
-- **`--private-key`:** The static private key of the wallet used for creating the CM Account (without the `0x` prefix).
+- **`--private-key`:** The static private key of the wallet used for creating the CM Account.
 - **`--bot`:** The address of the bot you are registering. Ensure that this address is your C-chain address and not the same as your CM Account wallet.
 - **`--network`:** Specify the network (as configured in the `hardhat.config.json`).
 
@@ -583,7 +583,7 @@ Done in 2.11s.
 #### Command Parameters
 
 - **`--cm-account`:** The EVM contract address of your CM Account.
-- **`--private-key`:** The static private key of the wallet used to create your CM Account (without the `0x` prefix).
+- **`--private-key`:** The static private key of the wallet used to create your CM Account.
 - **`--service-name`:** The full-service name to register. For a complete list of supported services, consult the [Camino Messenger Protocol documentation](https://buf.build/chain4travel/camino-messenger-protocol/docs). (You can also check the service names here in the [services](./services/) folder)
 - **`--fee`:** The service fee associated with your service in `aCAM` (`wei` in EVM terms).
 - **`--network`:** Specify the network (as configured in the `hardhat.config.json`).

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Chain4Travel is running the first and currently only messenger server.
 
 For network fee cheques, the Camino Messenger Bot should use the values above for:
 
--   `fromCMAccount`: Partner's CM Account address.
--   `toCMAccount`: The "**Messenger CM Account**" address from the tables above.
--   `toBot`: The "**Messenger Service Bot**" address from the tables above.
+- `fromCMAccount`: Partner's CM Account address.
+- `toCMAccount`: The "**Messenger CM Account**" address from the tables above.
+- `toBot`: The "**Messenger Service Bot**" address from the tables above.
 
 ## Quickstart
 
@@ -244,7 +244,7 @@ and verified. For more info see: https://eips.ethereum.org/EIPS/eip-712
 
 #### Cheque Typehash, Domain Typehash, and Domain Separator
 
--   **Cheque Typehash:** This is the `keccak256` hash of the MessengerCheque struct type.
+- **Cheque Typehash:** This is the `keccak256` hash of the MessengerCheque struct type.
 
     ```js
     function calculateMessengerChequeTypeHash() {
@@ -257,7 +257,7 @@ and verified. For more info see: https://eips.ethereum.org/EIPS/eip-712
     }
     ```
 
--   **Domain Typehash:** This is the `keccak256` hash of the EIP-712 domain type.
+- **Domain Typehash:** This is the `keccak256` hash of the EIP-712 domain type.
 
     ```js
     function calculateDomainTypeHash() {
@@ -268,8 +268,8 @@ and verified. For more info see: https://eips.ethereum.org/EIPS/eip-712
     }
     ```
 
--   **Domain Separator:** This is a hash that combines the domain typehash with the
-    name, version, and chain ID of the domain.
+- **Domain Separator:** This is a hash that combines the domain typehash with the
+  name, version, and chain ID of the domain.
 
     ```js
     function calculateDomainSeparator(domainName, domainVersion, chainId) {
@@ -426,11 +426,11 @@ function verifyCheque(
 This function does not only verify that the signer of the cheque is a registered bot
 on the CM Account, but also other verifications like:
 
--   If the `fromCMAccount` is the contract itself
--   If the address of `toCMAccount` is a registered CM Account on the manager
--   If `expiresAt` timestamp is bigger then `block.timestamp`
--   Last counter and last amount recorded on the contract are lower then the cheque's
--   If the `toBot` address has the required role (`CHEQUE_OPERATOR_ROLE`)
+- If the `fromCMAccount` is the contract itself
+- If the address of `toCMAccount` is a registered CM Account on the manager
+- If `expiresAt` timestamp is bigger then `block.timestamp`
+- Last counter and last amount recorded on the contract are lower then the cheque's
+- If the `toBot` address has the required role (`CHEQUE_OPERATOR_ROLE`)
 
 So, to only verify if cheque's signature is valid, without doing the verifications
 above (which can only be done on-chain), you can use the examples below.
@@ -466,9 +466,9 @@ Ethers.js, check out the [`test/ChequeManager.test.js`](test/ChequeManager.test.
 
 Before you begin, ensure you have completed the following steps:
 
--   **Compile the Contracts:** Make sure all contracts are compiled successfully.
--   **KYC Verification:** Complete KYC for your wallet, as deploying a new contract (your CM Account) requires it.
--   **Fund Your Wallet:** Use the faucet to fund your wallet. Your new CM Account will be initially credited with 100 CAM tokens, so please ensure that your wallet contains more than 100 CAM tokens.
+- **Compile the Contracts:** Make sure all contracts are compiled successfully.
+- **KYC Verification:** Complete KYC for your wallet, as deploying a new contract (your CM Account) requires it.
+- **Fund Your Wallet:** Use the faucet to fund your wallet. Your new CM Account will be initially credited with 100 CAM tokens, so please ensure that your wallet contains more than 100 CAM tokens.
 
 ### Creating a CM Account
 
@@ -478,11 +478,11 @@ To create your CM Account, run the following command:
 
 #### Command Parameters
 
--   **--private-key:**  
-    Enter the static private key of your wallet (omit the `0x` prefix).
+- **--private-key:**  
+  Enter the static private key of your wallet (omit the `0x` prefix).
 
--   **--network:**  
-    Specify the network where you wish to create your account (as configured in your `hardhat.config.json`).
+- **--network:**  
+  Specify the network where you wish to create your account (as configured in your `hardhat.config.json`).
 
 In the output of the command, you will get a new CM Account address, that you need to save and use in the following steps.
 
@@ -494,17 +494,17 @@ After creating your CM Account, you need to register the address of your bot. Ex
 
 #### Command Parameters
 
--   **--cm-account:**  
-    The EVM contract address of your newly created CM Account.
+- **--cm-account:**  
+  The EVM contract address of your newly created CM Account.
 
--   **--private-key:**  
-    The static private key of the wallet used for creating the CM Account (without the `0x` prefix).
+- **--private-key:**  
+  The static private key of the wallet used for creating the CM Account (without the `0x` prefix).
 
--   **--bot:**  
-    The address of the bot you are registering. Ensure that this address is your C-chain address and not the same as your CM Account wallet.
+- **--bot:**  
+  The address of the bot you are registering. Ensure that this address is your C-chain address and not the same as your CM Account wallet.
 
--   **--network:**  
-    Specify the network (as configured in your `hardhat.config.json`).
+- **--network:**  
+  Specify the network (as configured in your `hardhat.config.json`).
 
 ### Registering Services
 
@@ -514,20 +514,20 @@ With your CM Account and bot registered, you can now add supported services. For
 
 #### Command Parameters
 
--   **--cm-account:**  
-    The EVM contract address of your CM Account.
+- **--cm-account:**  
+  The EVM contract address of your CM Account.
 
--   **--private-key:**  
-    The static private key of the wallet used to create your CM Account (without the `0x` prefix).
+- **--private-key:**  
+  The static private key of the wallet used to create your CM Account (without the `0x` prefix).
 
--   **--service-name:**  
-    The full-service name to register. For a complete list of supported services, consult the [Camino Messenger Protocol documentation](https://buf.build/chain4travel/camino-messenger-protocol/docs).
+- **--service-name:**  
+  The full-service name to register. For a complete list of supported services, consult the [Camino Messenger Protocol documentation](https://buf.build/chain4travel/camino-messenger-protocol/docs).
 
--   **--fee:**  
-    The service fee associated with your service.
+- **--fee:**  
+  The service fee associated with your service.
 
--   **--network:**  
-    Specify the network (as configured in your `hardhat.config.json`).
+- **--network:**  
+  Specify the network (as configured in your `hardhat.config.json`).
 
 ## Summary
 


### PR DESCRIPTION
Updating the readme to guide through the process of creating a CM Account using hardhat.
Covering the prerequisites for creating a CM Account and adding the following steps:

- Creating a CM Account
- Registering a bot address to the CM Account
- Registering Services
