### PR TITLE
Add ERC20 Service Fee Token for Testing

### DIFF
--- a/contracts/test/ServiceFeeToken.sol
+++ b/contracts/test/ServiceFeeToken.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: UNLICENSED
+//
+// Service Fee Token Contract for testing purposes.
+
+pragma solidity 0.8.24;
+
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { ERC20BurnableUpgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
+import { ERC20PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PausableUpgradeable.sol";
+import { ERC20PermitUpgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+/**
+ * @title Service Fee Token for Testnet
+ * @notice This contract is intended to be used only on testnet as an ERC20 service
+ * fee token.
+ *
+ * For more info see:
+ * https://github.com/chain4travel/camino-messenger-contracts/
+ */
+contract ServiceFeeToken is
+    Initializable,
+    ERC20Upgradeable,
+    ERC20BurnableUpgradeable,
+    ERC20PausableUpgradeable,
+    AccessControlUpgradeable,
+    ERC20PermitUpgradeable,
+    UUPSUpgradeable
+{
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address defaultAdmin, address pauser, address minter, address upgrader) public initializer {
+        __ERC20_init("USD Service Fee Token", "USD.test");
+        __ERC20Burnable_init();
+        __ERC20Pausable_init();
+        __AccessControl_init();
+        __ERC20Permit_init("ServiceFeeToken");
+        __UUPSUpgradeable_init();
+
+        _grantRole(DEFAULT_ADMIN_ROLE, defaultAdmin);
+        _grantRole(PAUSER_ROLE, pauser);
+        _grantRole(MINTER_ROLE, minter);
+        _grantRole(UPGRADER_ROLE, upgrader);
+    }
+
+    function pause() public onlyRole(PAUSER_ROLE) {
+        _pause();
+    }
+
+    function unpause() public onlyRole(PAUSER_ROLE) {
+        _unpause();
+    }
+
+    function mint(address to, uint256 amount) public onlyRole(MINTER_ROLE) {
+        _mint(to, amount);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) {}
+
+    // The following functions are overrides required by Solidity.
+
+    function _update(
+        address from,
+        address to,
+        uint256 value
+    ) internal override(ERC20Upgradeable, ERC20PausableUpgradeable) {
+        super._update(from, to, value);
+    }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -3700,3 +3700,80 @@ function getVersion() public pure returns (string)
 ```solidity
 constructor() public
 ```
+
+## ServiceFeeToken
+
+This contract is intended to be used only on testnet as an ERC20 service
+fee token.
+
+For more info see:
+https://github.com/chain4travel/camino-messenger-contracts/
+
+### PAUSER_ROLE
+
+```solidity
+bytes32 PAUSER_ROLE
+```
+
+### MINTER_ROLE
+
+```solidity
+bytes32 MINTER_ROLE
+```
+
+### UPGRADER_ROLE
+
+```solidity
+bytes32 UPGRADER_ROLE
+```
+
+### constructor
+
+```solidity
+constructor() public
+```
+
+### initialize
+
+```solidity
+function initialize(address defaultAdmin, address pauser, address minter, address upgrader) public
+```
+
+### pause
+
+```solidity
+function pause() public
+```
+
+### unpause
+
+```solidity
+function unpause() public
+```
+
+### mint
+
+```solidity
+function mint(address to, uint256 amount) public
+```
+
+### \_authorizeUpgrade
+
+```solidity
+function _authorizeUpgrade(address newImplementation) internal
+```
+
+\_Function that should revert when `msg.sender` is not authorized to upgrade the contract. Called by
+{upgradeToAndCall}.
+
+Normally, this function will use an xref:access.adoc[access control] modifier such as {Ownable-onlyOwner}.
+
+````solidity
+function _authorizeUpgrade(address) internal onlyOwner {}
+```_
+
+### _update
+
+```solidity
+function _update(address from, address to, uint256 value) internal
+````

--- a/ignition/modules/sft_0_deploy.js
+++ b/ignition/modules/sft_0_deploy.js
@@ -1,0 +1,53 @@
+const { buildModule } = require("@nomicfoundation/hardhat-ignition/modules");
+const hre = require("hardhat");
+
+const ServiceFeeTokenModule = buildModule("ServiceFeeTokenModule", (m) => {
+    // Fail if network is camino
+    if (hre.network.name === "camino") {
+        console.log("⚠️  Do not deploy on Camino mainnet!");
+        throw new Error(`Unsupported network: ${hre.network.name}`);
+    }
+
+    /***************************************************
+     *                  SET ACCOUNTS                   *
+     ***************************************************/
+
+    // Use the first account as the admin. For local node this is the first account
+    // from hardhat's example accounts. For Camino (mainnet) and Columbus (testnet)
+    // this is the vars from hardhat's config vars CAMINO_DEPLOYER_PRIVATE_KEY and
+    // COLUMBUS_DEPLOYER_PRIVATE_KEY (defined in hardhat.config.js).
+    const admin = m.getAccount(0);
+
+    const pauser = m.getParameter("sftPauser", admin);
+    const minter = m.getParameter("sftMinter", admin);
+    const upgrader = m.getParameter("sftUpgrader", admin);
+
+    /***************************************************
+     *                SERVICE FEE TOKEN                *
+     ***************************************************/
+
+    // Deploy ServiceFeeToken implementation contract
+    const serviceFeeToken = m.contract("ServiceFeeToken");
+
+    // Encode the initialize function call for ServiceFeeToken
+    const initializeServiceFeeTokenData = m.encodeFunctionCall(serviceFeeToken, "initialize", [
+        admin,
+        pauser,
+        minter,
+        upgrader,
+    ]);
+
+    // Deploy the proxy contract for ServiceFeeToken with the initialize data
+    const ServiceFeeTokenProxy = m.contract("ERC1967Proxy", [serviceFeeToken, initializeServiceFeeTokenData], {
+        id: "ServiceFeeTokenERC1967Proxy",
+    });
+
+    // Create instance of the proxy contract with the ServiceFeeToken ABI
+    const serviceFeeTokenProxy = m.contractAt("ServiceFeeToken", ServiceFeeTokenProxy, {
+        id: "ServiceFeeTokenProxy",
+    });
+
+    return { serviceFeeTokenProxy };
+});
+
+module.exports = ServiceFeeTokenModule;

--- a/test/ServiceFeeToken.test.js
+++ b/test/ServiceFeeToken.test.js
@@ -1,0 +1,133 @@
+const { loadFixture } = require("@nomicfoundation/hardhat-toolbox/network-helpers");
+const { expect } = require("chai");
+
+const { ethers } = require("hardhat");
+
+const helpers = require("@nomicfoundation/hardhat-network-helpers");
+
+// Fixtures
+const {
+    setupSigners,
+    developerFeeBp,
+    deployCMAccountManagerFixture,
+    deployCMAccountImplFixture,
+    deployCMAccountManagerWithCMAccountImplFixture,
+    deployAndConfigureAllFixture,
+    deployCMAccountWithDepositFixture,
+    deployBookingTokenFixture,
+    deployBookingTokenWithNullUSDFixture,
+    deployCancellationSupportFixture,
+    deployServiceFeeTokenFixture,
+} = require("./utils/fixtures");
+
+describe("ServiceFeeToken", function () {
+    it("Should deploy", async function () {
+        const { serviceFeeToken } = await loadFixture(deployServiceFeeTokenFixture);
+
+        expect(await serviceFeeToken.name()).to.equal("USD Service Fee Token");
+        expect(await serviceFeeToken.symbol()).to.equal("USD.test");
+    });
+
+    it("Should pause/unpause", async function () {
+        const { serviceFeeToken } = await loadFixture(deployServiceFeeTokenFixture);
+
+        expect(await serviceFeeToken.paused()).to.be.false;
+
+        await serviceFeeToken.connect(signers.managerPauser).pause();
+        expect(await serviceFeeToken.paused()).to.be.true;
+
+        // Try to mint
+        const amount = ethers.parseEther("100");
+        await expect(
+            serviceFeeToken.connect(signers.withdrawer).mint(signers.otherAccount1.address, amount),
+        ).to.be.revertedWithCustomError(serviceFeeToken, "EnforcedPause");
+
+        // Try to transfer
+        await expect(
+            serviceFeeToken.connect(signers.otherAccount1).transfer(signers.otherAccount2.address, amount),
+        ).to.be.revertedWithCustomError(serviceFeeToken, "EnforcedPause");
+
+        // Try to burn
+        await expect(serviceFeeToken.connect(signers.otherAccount1).burn(amount)).to.be.revertedWithCustomError(
+            serviceFeeToken,
+            "EnforcedPause",
+        );
+
+        // unpause
+        await serviceFeeToken.connect(signers.managerPauser).unpause();
+        expect(await serviceFeeToken.paused()).to.be.false;
+
+        // Try to mint
+        await expect(serviceFeeToken.connect(signers.withdrawer).mint(signers.otherAccount1.address, amount)).to.be.not
+            .reverted;
+    });
+
+    it("Should mint", async function () {
+        const { serviceFeeToken } = await loadFixture(deployServiceFeeTokenFixture);
+
+        const amount = ethers.parseEther("100");
+
+        await expect(serviceFeeToken.connect(signers.withdrawer).mint(signers.otherAccount1.address, amount)).to.be.not
+            .reverted;
+
+        expect(await serviceFeeToken.balanceOf(signers.otherAccount1.address)).to.equal(amount);
+    });
+
+    it("Should burn", async function () {
+        const { serviceFeeToken } = await loadFixture(deployServiceFeeTokenFixture);
+
+        const amount = ethers.parseEther("100");
+
+        await serviceFeeToken.connect(signers.withdrawer).mint(signers.otherAccount1.address, amount);
+        expect(await serviceFeeToken.balanceOf(signers.otherAccount1.address)).to.equal(amount);
+
+        const burnAmount = ethers.parseEther("30");
+
+        await expect(serviceFeeToken.connect(signers.otherAccount1).burn(burnAmount)).to.be.not.reverted;
+
+        expect(await serviceFeeToken.balanceOf(signers.otherAccount1.address)).to.equal(amount - burnAmount);
+    });
+
+    it("Should transfer", async function () {
+        const { serviceFeeToken } = await loadFixture(deployServiceFeeTokenFixture);
+
+        const amount = ethers.parseEther("100");
+
+        await serviceFeeToken.connect(signers.withdrawer).mint(signers.otherAccount1.address, amount);
+        expect(await serviceFeeToken.balanceOf(signers.otherAccount1.address)).to.equal(amount);
+
+        await expect(serviceFeeToken.connect(signers.otherAccount1).transfer(signers.otherAccount2.address, amount)).to
+            .be.not.reverted;
+
+        expect(await serviceFeeToken.balanceOf(signers.otherAccount1.address)).to.equal(0);
+        expect(await serviceFeeToken.balanceOf(signers.otherAccount2.address)).to.equal(amount);
+    });
+
+    it("Should not allow unauthorized calls", async function () {
+        const { serviceFeeToken } = await loadFixture(deployServiceFeeTokenFixture);
+
+        const amount = ethers.parseEther("100");
+
+        // mint
+        await expect(
+            serviceFeeToken.connect(signers.otherAccount1).mint(signers.otherAccount2.address, amount),
+        ).to.be.revertedWithCustomError(serviceFeeToken, "AccessControlUnauthorizedAccount");
+
+        // pause
+        await expect(serviceFeeToken.connect(signers.otherAccount1).pause()).to.be.revertedWithCustomError(
+            serviceFeeToken,
+            "AccessControlUnauthorizedAccount",
+        );
+
+        // unpause
+        await expect(serviceFeeToken.connect(signers.otherAccount1).unpause()).to.be.revertedWithCustomError(
+            serviceFeeToken,
+            "AccessControlUnauthorizedAccount",
+        );
+
+        // upgrade to and call
+        await expect(
+            serviceFeeToken.connect(signers.otherAccount1).upgradeToAndCall(signers.otherAccount3.address, "0x"),
+        ).to.be.revertedWithCustomError(serviceFeeToken, "AccessControlUnauthorizedAccount");
+    });
+});

--- a/test/utils/fixtures.js
+++ b/test/utils/fixtures.js
@@ -64,6 +64,20 @@ async function deployNullUSDFixture() {
     return { nullUSD, nullUSDDecimals };
 }
 
+async function deployServiceFeeTokenFixture() {
+    // Set up signers
+    await setupSigners();
+
+    const ServiceFeeToken = await ethers.getContractFactory("ServiceFeeToken");
+    const serviceFeeToken = await upgrades.deployProxy(ServiceFeeToken, [
+        signers.feeAdmin.address, // admin
+        signers.managerPauser.address, // pauser
+        signers.withdrawer.address, // minter
+        signers.managerUpgrader.address, // upgrader
+    ]);
+    return { serviceFeeToken };
+}
+
 async function deployCMAccountManagerFixture() {
     // Set up signers
     await setupSigners();
@@ -594,4 +608,5 @@ module.exports = {
     deployBookingTokenWithNullUSDFixture,
     deployCancellationSupportFixture,
     deployNullUSDFixture,
+    deployServiceFeeTokenFixture,
 };


### PR DESCRIPTION
This PR adds an ERC20 service fee token that we'll use for testing on Columbus testnet. 