### PR TITLE
Update account create task with the new ERC20 service fee logic

### DIFF
--- a/tasks/account.js
+++ b/tasks/account.js
@@ -52,7 +52,11 @@ async function getCMAccount(cmAccountAddress) {
 
 async function getServiceFeeTokenFromManager(hre) {
     const manager = await getManager(hre);
-    return await ethers.getContractAt("ServiceFeeToken", await manager.getServiceFeeToken());
+    const sftAddress = await manager.getServiceFeeToken();
+    if (sftAddress === ethers.ZeroAddress) {
+        throw new Error("ServiceFeeToken is not configured on the CMAccountManager");
+    }
+    return await ethers.getContractAt("ServiceFeeToken", sftAddress);
 }
 
 async function handleRoles(taskArgs, hre, action) {

--- a/tasks/account.js
+++ b/tasks/account.js
@@ -50,6 +50,11 @@ async function getCMAccount(cmAccountAddress) {
     return await ethers.getContractAt("CMAccount", cmAccountAddress);
 }
 
+async function getServiceFeeTokenFromManager(hre) {
+    const manager = await getManager(hre);
+    return await ethers.getContractAt("ServiceFeeToken", await manager.getServiceFeeToken());
+}
+
 async function handleRoles(taskArgs, hre, action) {
     const cmAccount = await getCMAccount(taskArgs.cmAccount);
     console.log("CMAccount:", taskArgs.cmAccount);
@@ -199,17 +204,42 @@ ACCOUNT_SCOPE.task("role:all", "List all roles and their members")
 
 ACCOUNT_SCOPE.task("create", "Create CMAccount")
     .addOptionalParam("privateKey", "Private key to use, default: CMACCOUNT_PK env variable", process.env.CMACCOUNT_PK)
+    .addOptionalParam("camAmount", "Amount of CAM to send to CMAccount", "0")
     .setAction(async (taskArgs, hre) => {
         const manager = await getManager(hre);
+
+        console.log("We need to approve the ServiceFeeToken for the manager to create the CMAccount.");
+        console.log("Getting ServiceFeeToken...");
+        const serviceFeeToken = await getServiceFeeTokenFromManager(hre);
+        console.log("ServiceFeeToken Address:", await serviceFeeToken.getAddress());
+        console.log("ServiceFeeToken Name   :", await serviceFeeToken.name());
+        const sftSymbol = await serviceFeeToken.symbol();
+        const sftDecimals = await serviceFeeToken.decimals();
+        console.log("ServiceFeeToken Symbol :", sftSymbol);
+
         try {
             // Get signer from private key
             const signer = new ethers.Wallet(taskArgs.privateKey, ethers.provider);
-
-            console.log("Creating CMAccount...");
             console.log("Signer:", signer.address);
+
+            // Approve the Service Fee Token
+            // Get prefund amount
+            console.log("Getting Prefund Amount...");
+            const prefundAmount = await manager.getPrefundAmount();
+            const prefundAmountFormatted = ethers.formatUnits(prefundAmount, sftDecimals);
+            console.log("Prefund Amount:", prefundAmountFormatted);
+            console.log(`Approving the manager for ${prefundAmountFormatted} ${sftSymbol} ...`);
+            const txApprove = await serviceFeeToken.connect(signer).approve(await manager.getAddress(), prefundAmount);
+            const receiptApprove = await txApprove.wait();
+            console.log("Tx:", receiptApprove.hash);
+
+            // Create CMAccount
+            const parsedCAM = ethers.parseEther(taskArgs.camAmount);
+            const formattedCAM = ethers.formatEther(parsedCAM);
+            console.log(`Creating CMAccount... (Sending ${formattedCAM} CAM to the new CMAccount)`);
             const tx = await manager
                 .connect(signer)
-                .createCMAccount(signer.address, signer.address, { value: ethers.parseEther("100") });
+                .createCMAccount(signer.address, signer.address, { value: parsedCAM });
 
             const receipt = await tx.wait();
             console.log("Tx:", receipt.hash);


### PR DESCRIPTION
This PR updates the `account create` task according to the new ERC20 service fee logic.

```
Usage: hardhat [GLOBAL OPTIONS] account create [--cam-amount <STRING>] [--private-key <STRING>]

OPTIONS:

  --cam-amount  Amount of CAM to send to CMAccount (default: "0")
  --private-key Private key to use, default: CMACCOUNT_PK env variable 

create: Create CMAccount
```

```
❯ yarn hardhat account create --private-key <private-key-here> --network columbus  --cam-amount 10
yarn run v1.22.22
$ ./node_modules/.bin/hardhat account create --private-key <private-key> --network columbus --cam-amount 10
Running on columbus
We need to approve the ServiceFeeToken for the manager to create the CMAccount.
Getting ServiceFeeToken...
Running on columbus
ServiceFeeToken Address: 0x607539540Acc0221be30aA3f61995E3C003d561f
ServiceFeeToken Name   : USD Service Fee Token
ServiceFeeToken Symbol : USD.test
Signer: 0xFe77dcE375C3814F15F8035bCAC1A791D3dCdf21
Getting Prefund Amount...
Prefund Amount: 100.0
Approving the manager for 100.0 USD.test ...
Tx: 0xe90cfbac09daa3dd82c198453f373b1b0d04ed6b60266c60583c71667e99a2a3
Creating CMAccount... (Sending 10.0 CAM to the new CMAccount)
Tx: 0xa3f5f8492d945ab8ab778d4c82959ed8a7c17c537b26cafbb179084b16f3c23e
CMAccount Address: 0x1A42EaF111500EBc4f21D903dC97C31Dc68a5ade
Done in 3.66s.
```