### PR TITLE
Remove notification and cancellation service list

### DIFF
--- a/services/04_3_release-12-remove-notification-cancellation.json
+++ b/services/04_3_release-12-remove-notification-cancellation.json
@@ -1,0 +1,7 @@
+[
+    "cmp.services.notification.v1.NotificationService",
+    "cmp.services.notification.v2.NotificationService",
+    "cmp.services.notification.v3.NotificationService",
+    "cmp.services.cancellation.v1.CancellationService",
+    "cmp.services.cancellation.v2.CancellationService"
+]

--- a/services/04_3_release-12-remove-notification.json
+++ b/services/04_3_release-12-remove-notification.json
@@ -1,5 +1,0 @@
-[
-    "cmp.services.notification.v1.NotificationService",
-    "cmp.services.notification.v2.NotificationService",
-    "cmp.services.notification.v3.NotificationService"
-]

--- a/services/04_3_release-12-remove-notification.json
+++ b/services/04_3_release-12-remove-notification.json
@@ -1,0 +1,5 @@
+[
+    "cmp.services.notification.v1.NotificationService",
+    "cmp.services.notification.v2.NotificationService",
+    "cmp.services.notification.v3.NotificationService"
+]


### PR DESCRIPTION
This PR adds a remove list for notification and cancellation service, which are added by mistake. These are just for reference. The on-chain state is already fixed on Columbus testnet.